### PR TITLE
Add scalePropertiesSupportedByChannel Constraint

### DIFF
--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -246,13 +246,12 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
     strict: true,
     satisfy: (encQ: EncodingQuery) => {
       if (encQ) {
-        let channel = encQ.channel as Channel;
-        let scale = encQ.scale;
+        let channel: Channel = encQ.channel as Channel;
+        let scale: ScaleQuery = encQ.scale as ScaleQuery;
         if (channel && scale) {
-          let scaleProps = Object.keys(scale);
-          for (let scaleProp in scaleProps) {
+          for (let scaleProp in scale) {
 
-            if (!scaleProps.hasOwnProperty(scaleProp)) continue;
+            if (!scale.hasOwnProperty(scaleProp)) continue;
 
             if (scaleProp === 'type' || scaleProp === 'name' || scaleProp === 'enum') {
               // ignore type and properties of wildcards

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -1,6 +1,6 @@
 import {AggregateOp} from 'vega-lite/src/aggregate';
 import {Channel, getSupportedRole} from 'vega-lite/src/channel';
-import {ScaleType, scaleTypeSupportProperty, hasDiscreteDomain} from 'vega-lite/src/scale';
+import {ScaleType, scaleTypeSupportProperty, hasDiscreteDomain, channelScalePropertyIncompatability} from 'vega-lite/src/scale';
 import {Type} from 'vega-lite/src/type';
 
 import {AbstractConstraint, AbstractConstraintModel} from './base';
@@ -233,6 +233,28 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
             }
           } else if (!scaleTypeSupportProperty(sType, scaleProp)) {
             return false;
+          }
+        }
+      }
+      return true;
+    }
+  },{
+    name: 'scalePropertiesSupportedByChannel',
+    description: 'Not all scale properties are supported by all encoding channels',
+    properties: [Property.CHANNEL, Property.SCALE],
+    allowWildcardForProperties: false, // unsure about this
+    strict: true,
+    satisfy: (encQ: EncodingQuery) => {
+      if (encQ) {
+        let channel = encQ.channel as Channel;
+        let scale = encQ.scale;
+        if (channel && scale) {
+          let scaleProps = Object.keys(scale);
+          for (let scaleProp in scaleProps) {
+            let isSupported = channelScalePropertyIncompatability(channel, scaleProp) === undefined;
+            if (!isSupported) {
+              return false;
+            }
           }
         }
       }

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -242,13 +242,13 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
     name: 'scalePropertiesSupportedByChannel',
     description: 'Not all scale properties are supported by all encoding channels',
     properties: [Property.CHANNEL, Property.SCALE],
-    allowWildcardForProperties: false, // unsure about this
+    allowWildcardForProperties: true,
     strict: true,
     satisfy: (encQ: EncodingQuery) => {
       if (encQ) {
         let channel: Channel = encQ.channel as Channel;
         let scale: ScaleQuery = encQ.scale as ScaleQuery;
-        if (channel && scale) {
+        if (channel && !isWildcard(channel) && scale) {
           for (let scaleProp in scale) {
 
             if (!scale.hasOwnProperty(scaleProp)) continue;

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -244,7 +244,7 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
     properties: [].concat(SCALE_PROPS, [Property.SCALE, Property.CHANNEL]),
     allowWildcardForProperties: true,
     strict: true,
-    satisfy: (encQ: EncodingQuery) => {
+    satisfy: (encQ: EncodingQuery, _: Schema, __: PropIndex<Wildcard<any>>, ___: QueryConfig) => {
       if (encQ) {
         let channel: Channel = encQ.channel as Channel;
         let scale: ScaleQuery = encQ.scale as ScaleQuery;

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -251,6 +251,14 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
         if (channel && scale) {
           let scaleProps = Object.keys(scale);
           for (let scaleProp in scaleProps) {
+
+            if (!scaleProps.hasOwnProperty(scaleProp)) continue;
+
+            if (scaleProp === 'type' || scaleProp === 'name' || scaleProp === 'enum') {
+              // ignore type and properties of wildcards
+              continue;
+            }
+
             let isSupported = channelScalePropertyIncompatability(channel, scaleProp) === undefined;
             if (!isSupported) {
               return false;

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -241,7 +241,7 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
   },{
     name: 'scalePropertiesSupportedByChannel',
     description: 'Not all scale properties are supported by all encoding channels',
-    properties: [Property.CHANNEL, Property.SCALE],
+    properties: [SCALE_PROPS, Property.SCALE, Property.CHANNEL],
     allowWildcardForProperties: true,
     strict: true,
     satisfy: (encQ: EncodingQuery) => {

--- a/src/constraint/encoding.ts
+++ b/src/constraint/encoding.ts
@@ -241,7 +241,7 @@ export const ENCODING_CONSTRAINTS: EncodingConstraintModel[] = [
   },{
     name: 'scalePropertiesSupportedByChannel',
     description: 'Not all scale properties are supported by all encoding channels',
-    properties: [SCALE_PROPS, Property.SCALE, Property.CHANNEL],
+    properties: [].concat(SCALE_PROPS, [Property.SCALE, Property.CHANNEL]),
     allowWildcardForProperties: true,
     strict: true,
     satisfy: (encQ: EncodingQuery) => {

--- a/test/constraint/encoding.test.ts
+++ b/test/constraint/encoding.test.ts
@@ -634,6 +634,189 @@ describe('constraints/encoding', () => {
     });
   });
 
+  describe('scalePropertiesSupportedByChannel', () => {
+    it('should return true when channel is a wildcard', () => {
+      let encQ: EncodingQuery = {
+        channel: '?',
+        field: 'A',
+        type: '?',
+        scale: {
+          paddingInner: 20
+        }
+      };
+
+      assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('incompatible scale property range with channel x', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'x',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          range: [0, 10]
+        }
+      };
+
+      assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('incompatible scale property range with channel y', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'y',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          range: [0, 10]
+        }
+      };
+
+      assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('incompatible scale property range with channel row', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'row',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          range: [0, 10]
+        }
+      };
+
+      assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('incompatible scale property range with channel column', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'column',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          range: [0, 10]
+        }
+      };
+
+      assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('compatible scale property range with channel x2', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'x2',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          range: [0, 10]
+        }
+      };
+
+      assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('incompatible scale property rangeStep with channel row', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'row',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          rangeStep: 20
+        }
+      };
+
+      assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('incompatible scale property rangeStep with channel column', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'column',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          rangeStep: 20
+        }
+      };
+
+      assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('compatible scale property rangeStep with channel column', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'x',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          rangeStep: 20
+        }
+      };
+
+      assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('compatible scale property rangeStep with channel column', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'x',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          rangeStep: 20
+        }
+      };
+
+      assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('compatible scale property type with channel x with name, enum scale props', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'x',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          type: 'linear',
+          name: '?',
+          enum: '?'
+        }
+      };
+
+      assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('compatible scale property padding with channel x', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'x',
+        field: 'A',
+        type: 'quantitative',
+        scale: {
+          padding: 1.0,
+        }
+      };
+
+      assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+    it('returns true if missing scale', () => {
+      let encQ: EncodingQuery = {
+        // Scale type depends on channel, so this will make scale type ambiguous.
+        channel: 'x',
+        field: 'A',
+        type: 'quantitative'
+      };
+
+      assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+    });
+
+  });
+
   describe('typeMatchesSchemaType', () => {
     let encQ: EncodingQuery = {
       channel: Channel.X,

--- a/test/constraint/encoding.test.ts
+++ b/test/constraint/encoding.test.ts
@@ -648,7 +648,7 @@ describe('constraints/encoding', () => {
       assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('incompatible scale property range with channel x', () => {
+    it('should return false when scale property range with channel x', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'x',
@@ -662,7 +662,7 @@ describe('constraints/encoding', () => {
       assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('incompatible scale property range with channel y', () => {
+    it('should return false when scale property range with channel y', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'y',
@@ -676,7 +676,7 @@ describe('constraints/encoding', () => {
       assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('incompatible scale property range with channel row', () => {
+    it('should return false when scale property range with channel row', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'row',
@@ -690,7 +690,7 @@ describe('constraints/encoding', () => {
       assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('incompatible scale property range with channel column', () => {
+    it('should return false when scale property range with channel column', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'column',
@@ -704,7 +704,7 @@ describe('constraints/encoding', () => {
       assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('compatible scale property range with channel x2', () => {
+    it('should return true when scale property range with channel x2', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'x2',
@@ -718,7 +718,7 @@ describe('constraints/encoding', () => {
       assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('incompatible scale property rangeStep with channel row', () => {
+    it('should return false when scale property rangeStep with channel row', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'row',
@@ -732,7 +732,7 @@ describe('constraints/encoding', () => {
       assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('incompatible scale property rangeStep with channel column', () => {
+    it('should return false when scale property rangeStep with channel column', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'column',
@@ -746,7 +746,7 @@ describe('constraints/encoding', () => {
       assert.isFalse(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('compatible scale property rangeStep with channel column', () => {
+    it('should return true when scale property rangeStep with channel column', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'x',
@@ -760,7 +760,7 @@ describe('constraints/encoding', () => {
       assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('compatible scale property rangeStep with channel column', () => {
+    it('should return true when scale property rangeStep with channel column', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'x',
@@ -774,7 +774,7 @@ describe('constraints/encoding', () => {
       assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('compatible scale property type with channel x with name, enum scale props', () => {
+    it('should return true when scale property type with channel x with name, enum scale props', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'x',
@@ -790,7 +790,7 @@ describe('constraints/encoding', () => {
       assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('compatible scale property padding with channel x', () => {
+    it('should return true when scale property padding with channel x', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'x',
@@ -804,7 +804,7 @@ describe('constraints/encoding', () => {
       assert.isTrue(ENCODING_CONSTRAINT_INDEX['scalePropertiesSupportedByChannel'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
     });
 
-    it('returns true if missing scale', () => {
+    it('should return true when encoding query is missing scale prop', () => {
       let encQ: EncodingQuery = {
         // Scale type depends on channel, so this will make scale type ambiguous.
         channel: 'x',

--- a/test/enumerator.test.ts
+++ b/test/enumerator.test.ts
@@ -387,9 +387,9 @@ describe('enumerator', () => {
           mark: Mark.POINT,
           encodings: [
             {
-              channel: Channel.X,
+              channel: Channel.COLOR,
               scale: {
-                range: {enum: [undefined, ['cats', 'dogs'], ['chickens', 'pigs']]}
+                range: {enum: [undefined, ['red', 'blue'], ['green', 'black']]}
               },
               field: 'N',
               type: Type.NOMINAL
@@ -401,8 +401,8 @@ describe('enumerator', () => {
         const answerSet = enumerator([], specM);
         assert.equal(answerSet.length, 3);
         assert.deepEqual((answerSet[0].getEncodingQueryByIndex(0).scale as ScaleQuery).range, undefined);
-        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).range, ['cats', 'dogs']);
-        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).range, ['chickens', 'pigs']);
+        assert.deepEqual((answerSet[1].getEncodingQueryByIndex(0).scale as ScaleQuery).range, ['red', 'blue']);
+        assert.deepEqual((answerSet[2].getEncodingQueryByIndex(0).scale as ScaleQuery).range, ['green', 'black']);
       });
 
       it('should correctly enumerate scaleRange with number[] values', () => {
@@ -410,7 +410,7 @@ describe('enumerator', () => {
           mark: Mark.POINT,
           encodings: [
             {
-              channel: Channel.X,
+              channel: Channel.SIZE,
               scale: {
                 range: {enum: [undefined, [1,3], [5,7]]}
               },


### PR DESCRIPTION
Fix #174. Adds another encoding constraint because not all scale properties are supported by all encoding channels yet.
