### PR TITLE
Fix logic of the "omitTableWithOcclusionIfAutoAddCount

### DIFF
--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -606,8 +606,8 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
           if (specM.isAggregate()) { // TODO: refactor based on profiling statistics
             const xEncQ = specM.getEncodingQueryByChannel(Channel.X);
             const yEncQ = specM.getEncodingQueryByChannel(Channel.Y);
-            const xIsMeasure = xEncQ && isContinuous(xEncQ);
-            const yIsMeasure = yEncQ && isContinuous(yEncQ);
+            const xIsMeasure = isContinuous(xEncQ);
+            const yIsMeasure = isContinuous(yEncQ);
 
             // for aggregate line / area, we need at least one group-by axis and one measure axis.
             return xEncQ && yEncQ && (xIsMeasure !== yIsMeasure) &&
@@ -631,8 +631,8 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
             // Tick and Bar should have one and only one continuous axis
             const xEncQ = specM.getEncodingQueryByChannel(Channel.X);
             const yEncQ = specM.getEncodingQueryByChannel(Channel.Y);
-            const xIsContinuous = xEncQ && isContinuous(xEncQ);
-            const yIsContinuous = yEncQ && isContinuous(yEncQ);
+            const xIsContinuous = isContinuous(xEncQ);
+            const yIsContinuous = isContinuous(yEncQ);
             if (xIsContinuous !== yIsContinuous) {
               // TODO: Bar and tick's dimension should not be continuous (quant/time) scale
               return true;

--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -700,9 +700,9 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
         const xEncQ = specM.getEncodingQueryByChannel('x');
         const yEncQ = specM.getEncodingQueryByChannel('y');
 
-        // TODO(#186): take mark properties channel into account
-        if (isDiscrete(xEncQ) &&
-          isDiscrete(yEncQ) &&
+        // TODO(#186): take non-spatial channel into account
+        if ((!isFieldQuery(xEncQ) || isDiscrete(xEncQ)) &&
+          (!isFieldQuery(yEncQ) || isDiscrete(yEncQ)) &&
           !specM.isAggregate() // TODO: refactor based on statistics
         ) {
           return false;

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -102,16 +102,16 @@ export function toFieldDef(fieldQ: FieldQuery,
  * Is a field query continuous field?
  * This method is applicable only for fieldQuery without wildcard
  */
-export function isContinuous(fieldQ: FieldQuery) {
-  return vlFieldDef.isContinuous(toFieldDef(fieldQ, ['bin', 'timeUnit', 'field', 'type']));
+export function isContinuous(encQ: EncodingQuery) {
+  return isFieldQuery(encQ) && vlFieldDef.isContinuous(toFieldDef(encQ, ['bin', 'timeUnit', 'field', 'type']));
 }
 
 /**
  * Is a field query discrete field?
  * This method is applicable only for fieldQuery without wildcard
  */
-export function isDiscrete(fieldQ: FieldQuery) {
-  return vlFieldDef.isDiscrete(toFieldDef(fieldQ, ['bin', 'timeUnit', 'field', 'type']));
+export function isDiscrete(encQ: EncodingQuery) {
+  return isFieldQuery(encQ) && vlFieldDef.isDiscrete(toFieldDef(encQ, ['bin', 'timeUnit', 'field', 'type']));
 }
 
 /**

--- a/src/query/encoding.ts
+++ b/src/query/encoding.ts
@@ -32,7 +32,7 @@ export function isValueQuery(encQ: EncodingQuery): encQ is ValueQuery {
 }
 
 export function isFieldQuery(encQ: EncodingQuery): encQ is FieldQuery {
-  return encQ !== null && encQ !== undefined && (encQ['field'] || 'autoCount' in encQ);
+  return encQ !== null && encQ !== undefined && (encQ['field'] || 'autoCount' in encQ || encQ['aggregate'] === 'count');
 }
 
 // TODO: split this into FieldDefQuery and AutoCountQuery

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -1402,6 +1402,19 @@ describe('constraints/spec', () => {
 
       });
     });
+
+    it('return false for raw plot with both x and y are either empty or raw/unaggregated field.', () => {
+      [Mark.POINT, Mark.CIRCLE, Mark.SQUARE, Mark.LINE, Mark.AREA, Mark.BAR].forEach((mark) => {
+        const specM = buildSpecQueryModel({
+          mark: mark,
+          encodings: [
+            {channel: Channel.X, field: 'N', type: Type.NOMINAL}
+          ]
+        });
+        assert.isFalse(SPEC_CONSTRAINT_INDEX['omitTableWithOcclusionIfAutoAddCount'].satisfy(specM, schema, {autoAddCount: true}));
+
+      });
+    });
   });
 
   describe('omitVerticalDotPlot', () => {


### PR DESCRIPTION
When I try the below query, it returns `Uncaught TypeError: Cannot read property 'bin' of undefined`.  (I used `cars.json`.)
```json
{
  "spec": {
    "mark": "point",
    "encodings": [
      {
        "channel": "?",
        "field": "Acceleration", 
        "type": "quantitative",
        "bin": "?"
      }
    ]
  },
  "config": {
    "autoAddCount": true,
    "overlay": {
      "line": false
    }
  }
};
```
I guess it's because of the constraint doesn't check whether `yEncQ` and `xEncQ` are undefined. So I changed it. 

In addition, I think this constraint is still valid for 1D case. If it is, will it be better to add a new constraint?