### PR TITLE
temporal field should be able to be a group-by axis

### DIFF
--- a/src/constraint/spec.ts
+++ b/src/constraint/spec.ts
@@ -606,8 +606,8 @@ export const SPEC_CONSTRAINTS: SpecConstraintModel[] = [
           if (specM.isAggregate()) { // TODO: refactor based on profiling statistics
             const xEncQ = specM.getEncodingQueryByChannel(Channel.X);
             const yEncQ = specM.getEncodingQueryByChannel(Channel.Y);
-            const xIsMeasure = isContinuous(xEncQ);
-            const yIsMeasure = isContinuous(yEncQ);
+            const xIsMeasure = isContinuous(xEncQ) && !(isFieldQuery(xEncQ) && xEncQ.type === Type.TEMPORAL);
+            const yIsMeasure = isContinuous(yEncQ) && !(isFieldQuery(yEncQ) && yEncQ.type === Type.TEMPORAL);
 
             // for aggregate line / area, we need at least one group-by axis and one measure axis.
             return xEncQ && yEncQ && (xIsMeasure !== yIsMeasure) &&

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -329,7 +329,7 @@ describe('constraints/spec', () => {
     });
   });
 
-  describe('hasAppropriateGraphicTypeForMark', () => {
+  describe.only('hasAppropriateGraphicTypeForMark', () => {
     describe('bar, tick', () => {
       it('should return true for plots with one dimension and one measure on x/y', () => {
         [Mark.BAR, Mark.TICK].forEach((mark) => {
@@ -462,6 +462,19 @@ describe('constraints/spec', () => {
             ]
           });
           assert.isFalse(SPEC_CONSTRAINT_INDEX['hasAppropriateGraphicTypeForMark'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
+        });
+      });
+
+      it('should return true for aggregate line/area with one temporal field and one continuous field', () => {
+        [Mark.LINE, Mark.AREA].forEach((mark) => {
+          const specM = buildSpecQueryModel({
+            mark: mark,
+            encodings: [
+              {channel: Channel.X, field: 'T', type: Type.TEMPORAL, timeUnit: 'yearmonthdate'},
+              {channel: Channel.Y, field: 'Q', type: Type.QUANTITATIVE, aggregate: 'mean'}
+            ]
+          });
+          assert.isTrue(SPEC_CONSTRAINT_INDEX['hasAppropriateGraphicTypeForMark'].satisfy(specM, schema, DEFAULT_QUERY_CONFIG));
         });
       });
     });

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -329,7 +329,7 @@ describe('constraints/spec', () => {
     });
   });
 
-  describe.only('hasAppropriateGraphicTypeForMark', () => {
+  describe('hasAppropriateGraphicTypeForMark', () => {
     describe('bar, tick', () => {
       it('should return true for plots with one dimension and one measure on x/y', () => {
         [Mark.BAR, Mark.TICK].forEach((mark) => {


### PR DESCRIPTION
Because `isContinuous()` function in Vega-Lite returns `true` if temporal field has a non-periodic `timeUnit`, `hasAppropriateGraphicTypeForMark` rejects a spec having that temporal field and an aggregated quantitative field.

I changed `isMeasure` to be `false` when a field is temporal. (I thought a temporal field with any `timeUnit` can draw a line/area chart)

I couldn't add a test for this PR because master branch is broken so that I couldn't run `npm run test`.
Here is the case that current master is not working well:
```json
{
    "spec": {
      "mark": "line",
      "encodings": [
        {
          "channel": "?",
          "field": "Origin",
          "type": "nominal"
        },
        {
          "channel": "?",
          "field": "Accerleration",
          "type": "quantitative",
          "aggregate": "?"
        },
        {
          "channel": "?",
          "field": "Year",
          "type": "temporal",
          "timeUnit": "yearmonthdate"
        }
      ]
    },
    "config": {
      "autoAddCount": false
    }
  };
```
