### PR TITLE
Make Schema conform to Table Schema Spec.

### DIFF
--- a/src/constraint/field.ts
+++ b/src/constraint/field.ts
@@ -7,7 +7,7 @@ import {QueryConfig} from '../config';
 import {getEncodingNestedProp, Property, SCALE_PROPS} from '../property';
 import {PropIndex} from '../propindex';
 import {isWildcard, Wildcard} from '../wildcard';
-import {PrimitiveType, Schema} from '../schema';
+import {DataType, Schema} from '../schema';
 import {contains} from '../util';
 
 import {scaleType, FieldQuery, ScaleQuery, toFieldDef} from '../query/encoding';
@@ -208,7 +208,7 @@ export const FIELD_CONSTRAINTS: EncodingConstraintModel<FieldQuery>[] = [
         return true;
       }
 
-      const primitiveType = schema.primitiveType(fieldQ.field as string);
+      const primitiveType = schema.type(fieldQ.field as string);
       const type = fieldQ.type;
 
       if (!encWildcardIndex.has('field') && !encWildcardIndex.has('type') && !opt.constraintManuallySpecifiedValue) {
@@ -217,13 +217,13 @@ export const FIELD_CONSTRAINTS: EncodingConstraintModel<FieldQuery>[] = [
       }
 
       switch (primitiveType) {
-        case PrimitiveType.BOOLEAN:
-        case PrimitiveType.STRING:
+        case DataType.BOOLEAN:
+        case DataType.STRING:
           return type !== Type.QUANTITATIVE && type !== Type.TEMPORAL;
-        case PrimitiveType.NUMBER:
-        case PrimitiveType.INTEGER:
+        case DataType.NUMBER:
+        case DataType.INTEGER:
           return type !== Type.TEMPORAL;
-        case PrimitiveType.DATE:
+        case DataType.DATETIME:
           // TODO: add NOMINAL, ORDINAL support after we support this in Vega-Lite
           return type === Type.TEMPORAL;
         case null:
@@ -249,7 +249,7 @@ export const FIELD_CONSTRAINTS: EncodingConstraintModel<FieldQuery>[] = [
         return fieldQ.type === Type.QUANTITATIVE;
       }
 
-      return schema.type(fieldQ.field as string) === fieldQ.type;
+      return schema.vlType(fieldQ.field as string) === fieldQ.type;
     }
   },{
    name: 'maxCardinalityForCategoricalColor',

--- a/src/constraint/field.ts
+++ b/src/constraint/field.ts
@@ -7,7 +7,7 @@ import {QueryConfig} from '../config';
 import {getEncodingNestedProp, Property, SCALE_PROPS} from '../property';
 import {PropIndex} from '../propindex';
 import {isWildcard, Wildcard} from '../wildcard';
-import {DataType, Schema} from '../schema';
+import {PrimitiveType, Schema} from '../schema';
 import {contains} from '../util';
 
 import {scaleType, FieldQuery, ScaleQuery, toFieldDef} from '../query/encoding';
@@ -208,7 +208,7 @@ export const FIELD_CONSTRAINTS: EncodingConstraintModel<FieldQuery>[] = [
         return true;
       }
 
-      const primitiveType = schema.type(fieldQ.field as string);
+      const primitiveType = schema.primitiveType(fieldQ.field as string);
       const type = fieldQ.type;
 
       if (!encWildcardIndex.has('field') && !encWildcardIndex.has('type') && !opt.constraintManuallySpecifiedValue) {
@@ -217,13 +217,13 @@ export const FIELD_CONSTRAINTS: EncodingConstraintModel<FieldQuery>[] = [
       }
 
       switch (primitiveType) {
-        case DataType.BOOLEAN:
-        case DataType.STRING:
+        case PrimitiveType.BOOLEAN:
+        case PrimitiveType.STRING:
           return type !== Type.QUANTITATIVE && type !== Type.TEMPORAL;
-        case DataType.NUMBER:
-        case DataType.INTEGER:
+        case PrimitiveType.NUMBER:
+        case PrimitiveType.INTEGER:
           return type !== Type.TEMPORAL;
-        case DataType.DATETIME:
+        case PrimitiveType.DATETIME:
           // TODO: add NOMINAL, ORDINAL support after we support this in Vega-Lite
           return type === Type.TEMPORAL;
         case null:

--- a/src/ranking/fieldorder.ts
+++ b/src/ranking/fieldorder.ts
@@ -25,7 +25,7 @@ export function score(specM: SpecQueryModel, schema: Schema, _: QueryConfig): Ra
   }
 
   const encodings = specM.specQuery.encodings;
-  const numFields = schema.fieldSchemas.length;
+  const numFields = schema.fields.length;
 
   const features: FeatureScore[] = [];
   let totalScore = 0, base = 1;

--- a/src/ranking/fieldorder.ts
+++ b/src/ranking/fieldorder.ts
@@ -25,7 +25,7 @@ export function score(specM: SpecQueryModel, schema: Schema, _: QueryConfig): Ra
   }
 
   const encodings = specM.specQuery.encodings;
-  const numFields = schema.fields.length;
+  const numFields = schema.fieldSchemas.length;
 
   const features: FeatureScore[] = [];
   let totalScore = 0, base = 1;

--- a/src/wildcard.ts
+++ b/src/wildcard.ts
@@ -278,7 +278,7 @@ export const DEFAULT_ENUM_INDEX: EnumIndex = {
 export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryConfig): any[] {
   if (prop === 'field' || (isEncodingNestedProp(prop) && prop.parent === 'sort' && prop.child === 'field')) {
     // For field, by default enumerate all fields
-    return schema.names();
+    return schema.fieldNames();
   }
 
   let val;

--- a/src/wildcard.ts
+++ b/src/wildcard.ts
@@ -278,7 +278,7 @@ export const DEFAULT_ENUM_INDEX: EnumIndex = {
 export function getDefaultEnumValues(prop: Property, schema: Schema, opt: QueryConfig): any[] {
   if (prop === 'field' || (isEncodingNestedProp(prop) && prop.parent === 'sort' && prop.child === 'field')) {
     // For field, by default enumerate all fields
-    return schema.fields();
+    return schema.names();
   }
 
   let val;

--- a/test/constraint/spec.test.ts
+++ b/test/constraint/spec.test.ts
@@ -19,7 +19,7 @@ import {Property} from '../../src/property';
 import {duplicate, extend} from '../../src/util';
 
 describe('constraints/spec', () => {
-  const schema = new Schema([]);
+  const schema = new Schema({fields:[]});
 
   function buildSpecQueryModel(specQ: SpecQuery) {
     return SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG);

--- a/test/fixture.ts
+++ b/test/fixture.ts
@@ -1,26 +1,26 @@
 import {Type} from 'vega-lite/build/src/type';
 
-import {Schema, FieldSchema, PrimitiveType} from '../src/schema';
+import {Schema, FieldSchema, DataType} from '../src/schema';
 
 const fixtures: FieldSchema[] = [{
-  field: 'Q',
-  type: Type.QUANTITATIVE,
-  primitiveType: PrimitiveType.NUMBER,
+  name: 'Q',
+  vlType: Type.QUANTITATIVE,
+  type: DataType.NUMBER,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'Q1',
-  type: Type.QUANTITATIVE,
-  primitiveType: PrimitiveType.NUMBER,
+  name: 'Q1',
+  vlType: Type.QUANTITATIVE,
+  type: DataType.NUMBER,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'Q2',
-  type: Type.QUANTITATIVE,
-  primitiveType: PrimitiveType.NUMBER,
+  name: 'Q2',
+  vlType: Type.QUANTITATIVE,
+  type: DataType.NUMBER,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'T',
-  type: Type.TEMPORAL,
-  primitiveType: PrimitiveType.DATE,
+  name: 'T',
+  vlType: Type.TEMPORAL,
+  type: DataType.DATETIME,
   stats: {
     distinct: 100,
     unique: {'2000/1/1': 1, '2000/1/2': 1}
@@ -40,40 +40,40 @@ const fixtures: FieldSchema[] = [{
     }
   } as any
 },{
-  field: 'T1',
-  type: Type.TEMPORAL,
-  primitiveType: PrimitiveType.DATE,
+  name: 'T1',
+  vlType: Type.TEMPORAL,
+  type: DataType.DATETIME,
   stats: {distinct: 100} as any, // HACK so that we don't have to define all summary properties
   timeStats: {year: {distinct: 5}, month: {distinct: 12}, day: {distinct: 5}} as any
 },{
-  field: 'O',
-  type: Type.ORDINAL,
-  primitiveType: PrimitiveType.STRING,
+  name: 'O',
+  vlType: Type.ORDINAL,
+  type: DataType.STRING,
   stats: {distinct: 6} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'O_10',
-  type: Type.ORDINAL,
-  primitiveType: PrimitiveType.STRING,
+  name: 'O_10',
+  vlType: Type.ORDINAL,
+  type: DataType.STRING,
   stats: {distinct: 10} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'O_20',
-  type: Type.ORDINAL,
-  primitiveType: PrimitiveType.STRING,
+  name: 'O_20',
+  vlType: Type.ORDINAL,
+  type: DataType.STRING,
   stats: {distinct: 20} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'O_100',
-  type: Type.ORDINAL,
-  primitiveType: PrimitiveType.STRING,
+  name: 'O_100',
+  vlType: Type.ORDINAL,
+  type: DataType.STRING,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'N',
-  type: Type.NOMINAL,
-  primitiveType: PrimitiveType.STRING,
+  name: 'N',
+  vlType: Type.NOMINAL,
+  type: DataType.STRING,
   stats: {distinct: 6} as any // HACK so that we don't have to define all summary properties
 },{
-  field: 'N20',
-  type: Type.NOMINAL,
-  primitiveType: PrimitiveType.STRING,
+  name: 'N20',
+  vlType: Type.NOMINAL,
+  type: DataType.STRING,
   stats: {distinct: 20} as any // HACK so that we don't have to define all summary properties
 }];
 

--- a/test/fixture.ts
+++ b/test/fixture.ts
@@ -1,26 +1,26 @@
 import {Type} from 'vega-lite/build/src/type';
 
-import {Schema, FieldSchema, DataType} from '../src/schema';
+import {Schema, FieldSchema, PrimitiveType} from '../src/schema';
 
 const fixtures: FieldSchema[] = [{
   name: 'Q',
   vlType: Type.QUANTITATIVE,
-  type: DataType.NUMBER,
+  type: PrimitiveType.NUMBER,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'Q1',
   vlType: Type.QUANTITATIVE,
-  type: DataType.NUMBER,
+  type: PrimitiveType.NUMBER,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'Q2',
   vlType: Type.QUANTITATIVE,
-  type: DataType.NUMBER,
+  type: PrimitiveType.NUMBER,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'T',
   vlType: Type.TEMPORAL,
-  type: DataType.DATETIME,
+  type: PrimitiveType.DATETIME,
   stats: {
     distinct: 100,
     unique: {'2000/1/1': 1, '2000/1/2': 1}
@@ -42,38 +42,38 @@ const fixtures: FieldSchema[] = [{
 },{
   name: 'T1',
   vlType: Type.TEMPORAL,
-  type: DataType.DATETIME,
+  type: PrimitiveType.DATETIME,
   stats: {distinct: 100} as any, // HACK so that we don't have to define all summary properties
   timeStats: {year: {distinct: 5}, month: {distinct: 12}, day: {distinct: 5}} as any
 },{
   name: 'O',
   vlType: Type.ORDINAL,
-  type: DataType.STRING,
+  type: PrimitiveType.STRING,
   stats: {distinct: 6} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'O_10',
   vlType: Type.ORDINAL,
-  type: DataType.STRING,
+  type: PrimitiveType.STRING,
   stats: {distinct: 10} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'O_20',
   vlType: Type.ORDINAL,
-  type: DataType.STRING,
+  type: PrimitiveType.STRING,
   stats: {distinct: 20} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'O_100',
   vlType: Type.ORDINAL,
-  type: DataType.STRING,
+  type: PrimitiveType.STRING,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'N',
   vlType: Type.NOMINAL,
-  type: DataType.STRING,
+  type: PrimitiveType.STRING,
   stats: {distinct: 6} as any // HACK so that we don't have to define all summary properties
 },{
   name: 'N20',
   vlType: Type.NOMINAL,
-  type: DataType.STRING,
+  type: PrimitiveType.STRING,
   stats: {distinct: 20} as any // HACK so that we don't have to define all summary properties
 }];
 
@@ -82,4 +82,4 @@ for (let fieldSchema of fixtures) {
   fieldSchema.binStats = {};
 }
 
-export const schema = new Schema(fixtures);
+export const schema = new Schema({fields:fixtures});

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -19,7 +19,7 @@ import {duplicate, extend} from '../src/util';
 const DEFAULT_SPEC_CONFIG = DEFAULT_QUERY_CONFIG.defaultSpecConfig;
 
 describe('SpecQueryModel', () => {
-  const schema = new Schema([]);
+  const schema = new Schema({fields:[]});
 
   function buildSpecQueryModel(specQ: SpecQuery) {
     return SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG);
@@ -479,7 +479,7 @@ describe('SpecQueryModel', () => {
 });
 
 describe('SpecQueryModelGroup', () => {
-  const schema = new Schema([]);
+  const schema = new Schema({fields:[]});
 
   function buildSpecQueryModel(specQ: SpecQuery) {
     return SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG);

--- a/test/ranking/aggregation.test.ts
+++ b/test/ranking/aggregation.test.ts
@@ -20,7 +20,7 @@ function getScore(shortenedFields: string) {
 
       const field: string = encQ.field = split.length > 1 ? split[1] : split[0];
 
-      encQ.type = field === '*' ? Type.QUANTITATIVE : schema.type(field);
+      encQ.type = field === '*' ? Type.QUANTITATIVE : schema.vlType(field);
 
       if (split.length > 1) {
         const fn = split[0];

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -3,7 +3,7 @@ import {assert} from 'chai';
 import {Type} from 'vega-lite/build/src/type';
 import {Channel} from 'vega-lite/build/src/channel';
 
-import {Schema, build, DataType} from '../src/schema';
+import {Schema, build, PrimitiveType} from '../src/schema';
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {extend} from '../src/util';
 
@@ -15,7 +15,7 @@ describe('schema', () => {
       let schema = build(data);
 
       assert.isNotNull(schema);
-      assert.equal(schema.names().length, 0);
+      assert.equal(schema.fieldNames().length, 0);
     });
 
     it('should store FieldSchemas in the correct order', () => {
@@ -24,10 +24,10 @@ describe('schema', () => {
       ];
       let schema = build(data);
 
-      assert.equal(schema['fields'][0]['name'], 'c');
-      assert.equal(schema['fields'][1]['name'], 'a');
-      assert.equal(schema['fields'][2]['name'], 'b');
-      assert.equal(schema['fields'][3]['name'], 'd');
+      assert.equal(schema['fieldSchemas'][0]['name'], 'c');
+      assert.equal(schema['fieldSchemas'][1]['name'], 'a');
+      assert.equal(schema['fieldSchemas'][2]['name'], 'b');
+      assert.equal(schema['fieldSchemas'][3]['name'], 'd');
     });
   });
 
@@ -39,7 +39,7 @@ describe('schema', () => {
 
   describe('fields', () => {
     it('should return an array of the correct fields', () => {
-      const fields: string[] = schema.names();
+      const fields: string[] = schema.fieldNames();
 
       assert.equal(fields.length, 4);
       assert.notEqual(fields.indexOf('a'), -1);
@@ -51,10 +51,10 @@ describe('schema', () => {
 
   describe('type', () => {
     it('should return the expected primitive type of each field', () => {
-      assert.equal(schema.type('a'), DataType.INTEGER);
-      assert.equal(schema.type('b'), DataType.STRING);
-      assert.equal(schema.type('c'), DataType.NUMBER);
-      assert.equal(schema.type('d'), DataType.DATETIME);
+      assert.equal(schema.primitiveType('a'), PrimitiveType.INTEGER);
+      assert.equal(schema.primitiveType('b'), PrimitiveType.STRING);
+      assert.equal(schema.primitiveType('c'), PrimitiveType.NUMBER);
+      assert.equal(schema.primitiveType('d'), PrimitiveType.DATETIME);
     });
   });
 
@@ -234,7 +234,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearmonth'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 1);
     });
 
@@ -252,7 +252,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearmonth'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, numYears);
     });
 
@@ -264,7 +264,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearquarter'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 2);
 
       cardinalityData = [{a: 'June 21, 1996'}, {a: 'May 21, 1996'}];
@@ -274,7 +274,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearquarter'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 1);
     });
 
@@ -286,7 +286,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'year'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 1);
 
       cardinalityData = [{a: 'June 21, 2000'}, {a: 'June 21, 2010'}];
@@ -296,7 +296,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'year'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 2);
     });
 
@@ -314,7 +314,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'quartermonth'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 3);
     });
 
@@ -332,7 +332,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'hoursminutes'
       });
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 3);
     });
 
@@ -351,7 +351,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'year'
       }, true, true);
-      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATETIME);
       assert.equal(cardinality, 1);
       cardinality = cardinalitySchema.cardinality({
         field: 'a',
@@ -375,7 +375,7 @@ describe('schema', () => {
         field: 'a',
         channel: Channel.X,
       }, true, true);
-      assert.equal(cardinalitySchema.type('a'), DataType.INTEGER);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.INTEGER);
       assert.equal(cardinality, 1);
       cardinality = cardinalitySchema.cardinality({
         field: 'a',
@@ -399,7 +399,7 @@ describe('schema', () => {
         channel: Channel.X,
         bin: true
       }, true, true);
-      assert.equal(cardinalitySchema.type('a'), DataType.INTEGER);
+      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.INTEGER);
       assert.equal(cardinality, 10);
       cardinality = cardinalitySchema.cardinality({
         field: 'a',
@@ -517,6 +517,48 @@ describe('schema', () => {
       assert.equal(domain.length, 2);
       assert.equal(domain[0].getTime(), new Date('6/14/2016').getTime());
       assert.equal(domain[1].getTime(), new Date('7/14/2016').getTime());
+    });
+  });
+
+
+  describe('dataTable', () => {
+    const dataTableData = [
+      {a: 1, b: 1.1, c: 'a', d: 2.3},
+      {a: 2, b: 1.2, c: 'b', d: 3.4},
+      {a: 3, b: 1.3, c: 'c', d: 6.0},
+      {a: 4, b: 1.4, c: 'd', d: 7.2}
+    ];
+
+    const dataTable = {
+      fields: [
+        {name: 'a', type: PrimitiveType.INTEGER, title: 'a title', custom: 'la la la'},
+        {name: 'b', type: PrimitiveType.INTEGER}
+      ],
+      primaryKey: 'a'
+    };
+
+    // build schema with passed in dataTable schema
+    let dataTableSchema: Schema = build(dataTableData, {}, dataTable);
+
+    it('should have data table schema values override inferred values', () => {
+      assert.equal(dataTableSchema.primitiveType('b'), PrimitiveType.INTEGER);
+      // assert that a similar data type would get a different inferred primitive type
+      assert.equal(dataTableSchema.primitiveType('d'), PrimitiveType.NUMBER);
+    });
+
+    it('should retain custom values in fields', () => {
+      const rTableSchema = dataTableSchema.tableSchema();
+      // open question: should tableSchema() only return original schema-ed fields?
+      // shouldn't be an issue usually, as a valid table schema will include
+      // all fields in the data.
+      assert.equal(rTableSchema.fields.length, 4);
+      assert.equal(rTableSchema.fields[0].title, 'a title');
+      assert.equal((rTableSchema.fields[0] as any).custom, 'la la la');
+    });
+
+    it('should retain data table schema level attributes passed in', () => {
+      const rTableSchema = dataTableSchema.tableSchema();
+      assert.equal((rTableSchema.primaryKey), 'a');
     });
   });
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -24,10 +24,10 @@ describe('schema', () => {
       ];
       let schema = build(data);
 
-      assert.equal(schema['fieldSchemas'][0]['name'], 'c');
-      assert.equal(schema['fieldSchemas'][1]['name'], 'a');
-      assert.equal(schema['fieldSchemas'][2]['name'], 'b');
-      assert.equal(schema['fieldSchemas'][3]['name'], 'd');
+      assert.equal(schema['fields'][0]['name'], 'c');
+      assert.equal(schema['fields'][1]['name'], 'a');
+      assert.equal(schema['fields'][2]['name'], 'b');
+      assert.equal(schema['fields'][3]['name'], 'd');
     });
   });
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -3,7 +3,7 @@ import {assert} from 'chai';
 import {Type} from 'vega-lite/build/src/type';
 import {Channel} from 'vega-lite/build/src/channel';
 
-import {Schema, build, PrimitiveType} from '../src/schema';
+import {Schema, build, DataType} from '../src/schema';
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {extend} from '../src/util';
 
@@ -15,7 +15,7 @@ describe('schema', () => {
       let schema = build(data);
 
       assert.isNotNull(schema);
-      assert.equal(schema.fields().length, 0);
+      assert.equal(schema.names().length, 0);
     });
 
     it('should store FieldSchemas in the correct order', () => {
@@ -24,10 +24,10 @@ describe('schema', () => {
       ];
       let schema = build(data);
 
-      assert.equal(schema['fieldSchemas'][0]['field'], 'c');
-      assert.equal(schema['fieldSchemas'][1]['field'], 'a');
-      assert.equal(schema['fieldSchemas'][2]['field'], 'b');
-      assert.equal(schema['fieldSchemas'][3]['field'], 'd');
+      assert.equal(schema['fieldSchemas'][0]['name'], 'c');
+      assert.equal(schema['fieldSchemas'][1]['name'], 'a');
+      assert.equal(schema['fieldSchemas'][2]['name'], 'b');
+      assert.equal(schema['fieldSchemas'][3]['name'], 'd');
     });
   });
 
@@ -39,7 +39,7 @@ describe('schema', () => {
 
   describe('fields', () => {
     it('should return an array of the correct fields', () => {
-      const fields: string[] = schema.fields();
+      const fields: string[] = schema.names();
 
       assert.equal(fields.length, 4);
       assert.notEqual(fields.indexOf('a'), -1);
@@ -49,26 +49,26 @@ describe('schema', () => {
     });
   });
 
-  describe('primitiveType', () => {
+  describe('type', () => {
     it('should return the expected primitive type of each field', () => {
-      assert.equal(schema.primitiveType('a'), PrimitiveType.INTEGER);
-      assert.equal(schema.primitiveType('b'), PrimitiveType.STRING);
-      assert.equal(schema.primitiveType('c'), PrimitiveType.NUMBER);
-      assert.equal(schema.primitiveType('d'), PrimitiveType.DATE);
+      assert.equal(schema.type('a'), DataType.INTEGER);
+      assert.equal(schema.type('b'), DataType.STRING);
+      assert.equal(schema.type('c'), DataType.NUMBER);
+      assert.equal(schema.type('d'), DataType.DATETIME);
     });
   });
 
-  describe('type', () => {
+  describe('vlType', () => {
     let configWithOrdinalInference = extend({}, DEFAULT_QUERY_CONFIG, {
       numberOrdinalProportion: .05,
       numberOrdinalLimit: 50,
     });
 
     it('should return the correct type of measurement for each field', () => {
-      assert.equal(schema.type('a'), Type.QUANTITATIVE);
-      assert.equal(schema.type('b'), Type.NOMINAL);
-      assert.equal(schema.type('c'), Type.QUANTITATIVE);
-      assert.equal(schema.type('d'), Type.TEMPORAL);
+      assert.equal(schema.vlType('a'), Type.QUANTITATIVE);
+      assert.equal(schema.vlType('b'), Type.NOMINAL);
+      assert.equal(schema.vlType('c'), Type.QUANTITATIVE);
+      assert.equal(schema.vlType('d'), Type.TEMPORAL);
     });
 
     it('should infer quantitative type for integers when cardinality is much less than the total but distinct is high', () => {
@@ -83,7 +83,7 @@ describe('schema', () => {
         numberData.push({a: i});
       }
       const numberSchema = build(numberData, configWithOrdinalInference);
-      assert.equal(numberSchema.type('a'), Type.QUANTITATIVE);
+      assert.equal(numberSchema.vlType('a'), Type.QUANTITATIVE);
     });
 
     it('should infer nominal type for integers when cardinality is much less than the total', () => {
@@ -94,7 +94,7 @@ describe('schema', () => {
         numberData.push({a: 1});
       }
       const numberSchema = build(numberData, configWithOrdinalInference);
-      assert.equal(numberSchema.type('a'), Type.NOMINAL);
+      assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
 
     it('should infer nominal type for 0, 1, 2 integers when cardinality is much less than the total', () => {
@@ -108,7 +108,7 @@ describe('schema', () => {
         numberData.push({a: 2});
       }
       const numberSchema = build(numberData, configWithOrdinalInference);
-      assert.equal(numberSchema.type('a'), Type.NOMINAL);
+      assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
 
     it('should infer nominal type for 1, 2, 3 integers when cardinality is much less than the total', () => {
@@ -122,7 +122,7 @@ describe('schema', () => {
         numberData.push({a: 3});
       }
       const numberSchema = build(numberData, configWithOrdinalInference);
-      assert.equal(numberSchema.type('a'), Type.NOMINAL);
+      assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
   });
 
@@ -234,7 +234,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearmonth'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 1);
     });
 
@@ -252,7 +252,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearmonth'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, numYears);
     });
 
@@ -264,7 +264,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearquarter'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 2);
 
       cardinalityData = [{a: 'June 21, 1996'}, {a: 'May 21, 1996'}];
@@ -274,7 +274,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'yearquarter'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 1);
     });
 
@@ -286,7 +286,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'year'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 1);
 
       cardinalityData = [{a: 'June 21, 2000'}, {a: 'June 21, 2010'}];
@@ -296,7 +296,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'year'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 2);
     });
 
@@ -314,7 +314,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'quartermonth'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 3);
     });
 
@@ -332,7 +332,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'hoursminutes'
       });
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 3);
     });
 
@@ -351,7 +351,7 @@ describe('schema', () => {
         channel: Channel.X,
         timeUnit: 'year'
       }, true, true);
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.DATE);
+      assert.equal(cardinalitySchema.type('a'), DataType.DATETIME);
       assert.equal(cardinality, 1);
       cardinality = cardinalitySchema.cardinality({
         field: 'a',
@@ -375,7 +375,7 @@ describe('schema', () => {
         field: 'a',
         channel: Channel.X,
       }, true, true);
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.INTEGER);
+      assert.equal(cardinalitySchema.type('a'), DataType.INTEGER);
       assert.equal(cardinality, 1);
       cardinality = cardinalitySchema.cardinality({
         field: 'a',
@@ -399,7 +399,7 @@ describe('schema', () => {
         channel: Channel.X,
         bin: true
       }, true, true);
-      assert.equal(cardinalitySchema.primitiveType('a'), PrimitiveType.INTEGER);
+      assert.equal(cardinalitySchema.type('a'), DataType.INTEGER);
       assert.equal(cardinality, 10);
       cardinality = cardinalitySchema.cardinality({
         field: 'a',

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -82,7 +82,7 @@ describe('schema', () => {
       for (let i = 0; i < configWithOrdinalInference.numberOrdinalLimit + 1; i++) {
         numberData.push({a: i});
       }
-      const numberSchema = build(numberData, configWithOrdinalInference);
+      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.QUANTITATIVE);
     });
 
@@ -93,7 +93,7 @@ describe('schema', () => {
       for (let i = 0; i < total; i++) {
         numberData.push({a: 1});
       }
-      const numberSchema = build(numberData, configWithOrdinalInference);
+      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
 
@@ -107,7 +107,7 @@ describe('schema', () => {
         numberData.push({a: 1});
         numberData.push({a: 2});
       }
-      const numberSchema = build(numberData, configWithOrdinalInference);
+      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
 
@@ -121,7 +121,7 @@ describe('schema', () => {
         numberData.push({a: 2});
         numberData.push({a: 3});
       }
-      const numberSchema = build(numberData, configWithOrdinalInference);
+      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
   });
@@ -538,7 +538,7 @@ describe('schema', () => {
     };
 
     // build schema with passed in dataTable schema
-    let dataTableSchema: Schema = build(dataTableData, {}, dataTable);
+    let dataTableSchema: Schema = build(dataTableData, dataTable);
 
     it('should have data table schema values override inferred values', () => {
       assert.equal(dataTableSchema.primitiveType('b'), PrimitiveType.INTEGER);
@@ -548,6 +548,7 @@ describe('schema', () => {
 
     it('should retain custom values in fields', () => {
       const rTableSchema = dataTableSchema.tableSchema();
+
       // open question: should tableSchema() only return original schema-ed fields?
       // shouldn't be an issue usually, as a valid table schema will include
       // all fields in the data.

--- a/test/wildcard.test.ts
+++ b/test/wildcard.test.ts
@@ -91,7 +91,7 @@ describe('wildcard', () => {
     it('should return enum for every properties by default', () => {
       const missing = [];
       const mockSchema = {
-        fields: () => ['a','b']
+        names: () => ['a','b']
       } as any;
       for (const prop of DEFAULT_PROP_PRECEDENCE) {
         const e = getDefaultEnumValues(prop, mockSchema, DEFAULT_QUERY_CONFIG);
@@ -107,7 +107,7 @@ describe('wildcard', () => {
     it('should return enum for every properties by default.', () => {
       const missing = [];
       const mockSchema = {
-        fields: () => ['a','b']
+        names: () => ['a','b']
       } as any;
       for (const prop of DEFAULT_PROP_PRECEDENCE) {
         const e =getDefaultEnumValues(prop, mockSchema, DEFAULT_QUERY_CONFIG);

--- a/test/wildcard.test.ts
+++ b/test/wildcard.test.ts
@@ -91,7 +91,7 @@ describe('wildcard', () => {
     it('should return enum for every properties by default', () => {
       const missing = [];
       const mockSchema = {
-        names: () => ['a','b']
+        fieldNames: () => ['a','b']
       } as any;
       for (const prop of DEFAULT_PROP_PRECEDENCE) {
         const e = getDefaultEnumValues(prop, mockSchema, DEFAULT_QUERY_CONFIG);
@@ -107,7 +107,7 @@ describe('wildcard', () => {
     it('should return enum for every properties by default.', () => {
       const missing = [];
       const mockSchema = {
-        names: () => ['a','b']
+        fieldNames: () => ['a','b']
       } as any;
       for (const prop of DEFAULT_PROP_PRECEDENCE) {
         const e =getDefaultEnumValues(prop, mockSchema, DEFAULT_QUERY_CONFIG);


### PR DESCRIPTION
This changes the `Schema` interface to be compliant with the Table Schema spec. 

https://specs.frictionlessdata.io/table-schema/

As discussed in https://github.com/vega/voyager/issues/338, here we:

* provide interfaces for `TableSchemaFieldDescriptor` and `TableSchema`
* rename field to name - the required ID of the field
* rename type to vlType - as this is additional data not captured in table schema
* rename primitiveType to type
* rename primitiveType date to datetime.

This introduces some inconsistencies between this new `Schema` and (for example) the `FieldQuery` interface (field === name). we can work toward changing more interfaces if this is a problem. 