### PR TITLE
Fix #85: Do not apply bin to a quantitative field with too low cardinality

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -53,8 +53,8 @@ export interface QueryConfig {
   preferredNominalAxis?: Channel;
   preferredFacet?: Channel;
 
-  // Encoding Constraints
-
+  // Field Encoding Constraints
+  minCardinalityForBin?: number;
   maxCardinalityForCategoricalColor?: number;
   maxCardinalityForFacet?: number;
   maxCardinalityForShape?: number;
@@ -113,7 +113,8 @@ export const DEFAULT_QUERY_CONFIG: QueryConfig = {
   preferredNominalAxis: Channel.Y, // nominal on y makes it easier to read.
   preferredFacet: Channel.ROW, // row make it easier to scroll than column
 
-  // Encoding Constraints -- See description inside src/constraints/encoding.ts
+  // Field Encoding Constraints -- See description inside src/constraint/field.ts
+  minCardinalityForBin: 15,
   maxCardinalityForCategoricalColor: 20,
   maxCardinalityForFacet: 20,
   maxCardinalityForShape: 6,

--- a/test/constraint/field.test.ts
+++ b/test/constraint/field.test.ts
@@ -139,6 +139,32 @@ describe('constraints/field', () => {
     });
   });
 
+  describe('minCardinalityForBin', () => {
+    it('should return false for binned quantitative field that has low cardinality', () => {
+      ['Q5', 'Q10'].forEach((field) => {
+        const encQ: EncodingQuery = {
+          channel: Channel.X,
+          bin: true,
+          field: field,
+          type: Type.QUANTITATIVE
+        };
+        assert.isFalse(FIELD_CONSTRAINT_INDEX['minCardinalityForBin'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+      });
+    });
+
+    it('should return true for binned quantitative field that has high enough cardinality', () => {
+      ['Q15', 'Q20', 'Q'].forEach((field) => {
+        const encQ: EncodingQuery = {
+          channel: Channel.X,
+          bin: true,
+          field: field,
+          type: Type.QUANTITATIVE
+        };
+        assert.isTrue(FIELD_CONSTRAINT_INDEX['minCardinalityForBin'].satisfy(encQ, schema, new PropIndex<Wildcard<any>>(), defaultOpt));
+      });
+    });
+  });
+
   describe('binAppliedForQuantitative', () => {
     let encQ: FieldQuery = {
       channel: Channel.X,

--- a/test/fixture.ts
+++ b/test/fixture.ts
@@ -18,6 +18,26 @@ const fixtures: FieldSchema[] = [{
   type: PrimitiveType.NUMBER,
   stats: {distinct: 100} as any // HACK so that we don't have to define all summary properties
 },{
+  name: 'Q5',
+  vlType: Type.QUANTITATIVE,
+  type: PrimitiveType.NUMBER,
+  stats: {distinct: 5} as any // HACK so that we don't have to define all summary properties
+},{
+  name: 'Q10',
+  vlType: Type.QUANTITATIVE,
+  type: PrimitiveType.NUMBER,
+  stats: {distinct: 10} as any // HACK so that we don't have to define all summary properties
+},{
+  name: 'Q15',
+  vlType: Type.QUANTITATIVE,
+  type: PrimitiveType.NUMBER,
+  stats: {distinct: 15} as any // HACK so that we don't have to define all summary properties
+},{
+  name: 'Q20',
+  vlType: Type.QUANTITATIVE,
+  type: PrimitiveType.NUMBER,
+  stats: {distinct: 20} as any // HACK so that we don't have to define all summary properties
+},{
   name: 'T',
   vlType: Type.TEMPORAL,
   type: PrimitiveType.DATETIME,


### PR DESCRIPTION
Fix #85 
Min cardinality threshold is currently set at 15, but we can move it up or down later after playing with it.

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case
- [x] Make lint and test pass. (Run `npm run lint` and `npm run test`)
- [x] Make sure you have merged `master` into your branch.
- [x] Provide a concise title so that we can just copy it to our release note.


