### PR TITLE
Add Domain to Schema for customizing ordinal's natural order

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -292,7 +292,7 @@ export class SpecQueryModel {
         // if the property is a wildcard, return null
         if (isWildcard(encQ[prop])) return null;
 
-        // otherwise, assign the proper to the field def
+        // otherwise, assign the property to the field def
         if (encQ[prop] !== undefined) {
 
           if (!PROPERTY_SUPPORTED_CHANNELS[prop] ||  // all channels support this prop
@@ -305,8 +305,21 @@ export class SpecQueryModel {
 
                 let fieldSchema = this._schema.fieldSchema(field as string);
                 if (fieldSchema.ordinalDomain && !encQ[prop]['domain']) {
-                  fieldDef[prop] = extend(encQ[prop], {domain: fieldSchema.originalIndex});
+                  fieldDef[prop] = extend(encQ[prop], {domain: fieldSchema.ordinalDomain});
                 }
+              }
+            }
+          }
+          // if the encoding query doesn't have scale, but the schema does
+        } else if (prop === Property.SCALE) {
+          if (!PROPERTY_SUPPORTED_CHANNELS[Property.SCALE] ||
+            PROPERTY_SUPPORTED_CHANNELS[Property.SCALE][encQ.channel as Channel]) {
+            if (isFieldQuery(encQ)) {
+              let field = encQ.field;
+
+              let fieldSchema = this._schema.fieldSchema(field as string);
+              if (fieldSchema.ordinalDomain) {
+                fieldDef[Property.SCALE] = {domain: fieldSchema.ordinalDomain};
               }
             }
           }

--- a/src/model.ts
+++ b/src/model.ts
@@ -298,6 +298,17 @@ export class SpecQueryModel {
           if (!PROPERTY_SUPPORTED_CHANNELS[prop] ||  // all channels support this prop
             PROPERTY_SUPPORTED_CHANNELS[prop][encQ.channel as Channel]) {
             fieldDef[prop] = encQ[prop];
+
+            if (prop === Property.SCALE) {
+              if (isFieldQuery(encQ)) {
+                let field = encQ.field;
+
+                let fieldSchema = this._schema.fieldSchema(field as string);
+                if (fieldSchema.ordinalDomain && !encQ[prop]['domain']) {
+                  fieldDef[prop] = extend(encQ[prop], {domain: fieldSchema.originalIndex});
+                }
+              }
+            }
           }
         }
       }

--- a/src/model.ts
+++ b/src/model.ts
@@ -290,10 +290,10 @@ export class SpecQueryModel {
       for (const prop of PROPERTIES) {
 
         // if the property is a wildcard, return null
-        if (isWildcard(encQ[prop])) return null;
-
+        if (isWildcard(encQ[prop])) {
+          return null;
+        } else if (encQ[prop] !== undefined) {
         // otherwise, assign the property to the field def
-        if (encQ[prop] !== undefined) {
 
           if (!PROPERTY_SUPPORTED_CHANNELS[prop] ||  // all channels support this prop
             PROPERTY_SUPPORTED_CHANNELS[prop][encQ.channel as Channel]) {
@@ -304,6 +304,7 @@ export class SpecQueryModel {
                 let field = encQ.field;
 
                 let fieldSchema = this._schema.fieldSchema(field as string);
+                // we use ['domain'] accessor hack because Typescript can't infer between FlatQuery and Wildcard
                 if (fieldSchema.ordinalDomain && !encQ[prop]['domain']) {
                   fieldDef[prop] = extend(encQ[prop], {domain: fieldSchema.ordinalDomain});
                 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -300,7 +300,7 @@ export class SpecQueryModel {
             fieldDef[prop] = encQ[prop];
 
             if (prop === Property.SCALE) {
-              if (isFieldQuery(encQ)) {
+              if (isFieldQuery(encQ) && encQ.type === Type.ORDINAL) {
                 let field = encQ.field;
 
                 let fieldSchema = this._schema.fieldSchema(field as string);
@@ -315,7 +315,7 @@ export class SpecQueryModel {
         } else if (prop === Property.SCALE) {
           if (!PROPERTY_SUPPORTED_CHANNELS[Property.SCALE] ||
             PROPERTY_SUPPORTED_CHANNELS[Property.SCALE][encQ.channel as Channel]) {
-            if (isFieldQuery(encQ)) {
+            if (isFieldQuery(encQ) && encQ.type === Type.ORDINAL) {
               let field = encQ.field;
 
               let fieldSchema = this._schema.fieldSchema(field as string);

--- a/src/model.ts
+++ b/src/model.ts
@@ -306,7 +306,7 @@ export class SpecQueryModel {
               const scale = encQ.scale;
               const {ordinalDomain} = this._schema.fieldSchema(encQ.field as string);
 
-              if (scale && ordinalDomain) {
+              if (scale !== null && ordinalDomain) {
                 fieldDef[Property.SCALE] = {
                   domain: ordinalDomain,
                   // explicitly specfied domain property should override ordinalDomain

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -360,7 +360,7 @@ export class Schema {
       // coerce non-quantitative numerical data into number type
       domain = domain.map(x => +x);
       return domain.sort(cmp);
-    } else if ((fieldSchema.vlType === VLType.ORDINAL) && (fieldSchema.ordinalDomain !== null)) {
+    } else if ((fieldSchema.vlType === VLType.ORDINAL) && fieldSchema.ordinalDomain) {
       return fieldSchema.ordinalDomain;
     }
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -46,6 +46,9 @@ export interface FieldSchema extends TableSchemaFieldDescriptor {
   stats: DLFieldProfile;
   binStats?: {[maxbins: string]: DLFieldProfile};
   timeStats?: {[timeUnit: string]: DLFieldProfile};
+
+  // array of valid input values (fields)
+  ordinalDomain?: string[];
 }
 
 /**
@@ -357,6 +360,8 @@ export class Schema {
       // coerce non-quantitative numerical data into number type
       domain = domain.map(x => +x);
       return domain.sort(cmp);
+    } else if ((fieldSchema.vlType === VLType.ORDINAL) && (fieldSchema.ordinalDomain !== null)) {
+      return fieldSchema.ordinalDomain;
     }
 
     return domain.map((x) => {

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -1,11 +1,10 @@
 import {assert} from 'chai';
 
-
-
 import {Channel} from 'vega-lite/build/src/channel';
 import {Mark} from 'vega-lite/build/src/mark';
-
 import {Type} from 'vega-lite/build/src/type';
+
+import {schema} from './fixture';
 
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {isSpecQueryGroup, SpecQueryModel, SpecQueryModelGroup, getTopSpecQueryItem} from '../src/model';
@@ -19,8 +18,6 @@ import {duplicate, extend} from '../src/util';
 const DEFAULT_SPEC_CONFIG = DEFAULT_QUERY_CONFIG.defaultSpecConfig;
 
 describe('SpecQueryModel', () => {
-  const schema = new Schema({fields:[]});
-
   function buildSpecQueryModel(specQ: SpecQuery) {
     return SpecQueryModel.build(specQ, schema, DEFAULT_QUERY_CONFIG);
   }
@@ -269,19 +266,19 @@ describe('SpecQueryModel', () => {
   describe('toSpec', () => {
     it('should return a Vega-Lite spec if the query is completed', () => {
       const specM = buildSpecQueryModel({
-        data: {values: [{A: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encodings: [
           {
             channel: Channel.X,
-            field: 'A',
+            field: 'Q',
             type: Type.QUANTITATIVE,
             axis: {orient: 'top', shortTimeLabels: true, ticks: 5, title: 'test x channel'},
           },
           {
             channel: Channel.COLOR,
-            field: 'B',
+            field: 'Q2',
             type: Type.QUANTITATIVE,
             legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'},
           }
@@ -290,12 +287,12 @@ describe('SpecQueryModel', () => {
 
       const spec = specM.toSpec();
       assert.deepEqual(spec, {
-        data: {values: [{A: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', type: Type.QUANTITATIVE, axis: {orient: 'top', shortTimeLabels: true, ticks: 5, title: 'test x channel'}},
-          color: {field: 'B', type: Type.QUANTITATIVE, legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'}}
+          x: {field: 'Q', type: Type.QUANTITATIVE, axis: {orient: 'top', shortTimeLabels: true, ticks: 5, title: 'test x channel'}},
+          color: {field: 'Q2', type: Type.QUANTITATIVE, legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'}}
         },
         config: DEFAULT_SPEC_CONFIG
       });
@@ -303,13 +300,13 @@ describe('SpecQueryModel', () => {
 
     it('should return a Vega-Lite spec that does not output inapplicable legend', () => {
       const specM = buildSpecQueryModel({
-        data: {values: [{A: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encodings: [
           {
             channel: Channel.X,
-            field: 'A',
+            field: 'Q',
             type: Type.QUANTITATIVE,
             axis: {orient: 'top', shortTimeLabels: true, ticks: 5, title: 'test x channel'},
             legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'},
@@ -319,11 +316,11 @@ describe('SpecQueryModel', () => {
 
       const spec = specM.toSpec();
       assert.deepEqual(spec, {
-        data: {values: [{A: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', type: Type.QUANTITATIVE, axis: {orient: 'top', shortTimeLabels: true, ticks: 5, title: 'test x channel'}},
+          x: {field: 'Q', type: Type.QUANTITATIVE, axis: {orient: 'top', shortTimeLabels: true, ticks: 5, title: 'test x channel'}},
         },
         config: DEFAULT_SPEC_CONFIG
       });
@@ -331,13 +328,13 @@ describe('SpecQueryModel', () => {
 
     it('should return a Vega-Lite spec that does not output inapplicable axis', () => {
       const specM = buildSpecQueryModel({
-        data: {values: [{A: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encodings: [
           {
             channel: Channel.COLOR,
-            field: 'B',
+            field: 'Q2',
             type: Type.QUANTITATIVE,
             axis: {orient: 'top', shortTimeLabels: true, ticks: 5, title: 'test x channel'},
             legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'},
@@ -347,11 +344,11 @@ describe('SpecQueryModel', () => {
 
       const spec = specM.toSpec();
       assert.deepEqual(spec, {
-        data: {values: [{A: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encoding: {
-          color: {field: 'B', type: Type.QUANTITATIVE, legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'}}
+          color: {field: 'Q2', type: Type.QUANTITATIVE, legend: {orient: 'right', labelAlign: 'left', symbolSize: 12, title: 'test title'}}
         },
         config: DEFAULT_SPEC_CONFIG
       });
@@ -359,26 +356,26 @@ describe('SpecQueryModel', () => {
 
     it('should return a spec with no bin if the bin=false.', () => {
       const specM = buildSpecQueryModel({
-        data: {values: [{A: 1}]},
+        data: {values: [{Q: 1}]},
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, bin: false, field: 'A', type: Type.QUANTITATIVE}
+          {channel: Channel.X, bin: false, field: 'Q', type: Type.QUANTITATIVE}
         ]
       });
 
       const spec = specM.toSpec();
       assert.deepEqual(spec, {
-        data: {values: [{A: 1}]},
+        data: {values: [{Q: 1}]},
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', type: Type.QUANTITATIVE}
+          x: {field: 'Q', type: Type.QUANTITATIVE}
         },
         config: DEFAULT_SPEC_CONFIG
       });
     });
 
-    it.only('should return a spec with the domain specified in FieldSchema if the encoding query ' +
-            'did not originaly have scale', () => {
+    it('should return a spec with the domain specified in FieldSchema if the encoding query ' +
+       'did not originaly have scale', () => {
       const specM = SpecQueryModel.build(
         {
           data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
@@ -421,24 +418,108 @@ describe('SpecQueryModel', () => {
       });
     });
 
-    it('should return a spec with the domain specified in FieldSchema if the encoding query already has ');
+    it('should return a spec with the domain specified in FieldSchema if the encoding query ' +
+       'already has scale but does not have domain', () => {
+      const specM = SpecQueryModel.build(
+        {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encodings: [
+            {channel: Channel.X, field: 'A', type: Type.ORDINAL, scale: {}},
+            {channel: Channel.Y, field: 'B', type: Type.QUANTITATIVE}
+          ]
+        },
+        new Schema({fields:
+          [{
+            name: 'A',
+            vlType: 'ordinal',
+            type: 'string' as any,
+            ordinalDomain: ['S', 'M', 'L'],
+            stats: {
+              distinct: 3
+            }
+          },{
+            name: 'B',
+            vlType: 'quantitative',
+            type: 'number' as any,
+            stats: {
+              distinct: 3
+            }
+          }] as FieldSchema[]
+        }),
+        DEFAULT_QUERY_CONFIG
+      );
 
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encoding: {
+            x: {field: 'A', type: Type.ORDINAL, scale: {domain: ['S', 'M', 'L']}},
+            y: {field: 'B', type: Type.QUANTITATIVE}
+          },
+          config: DEFAULT_SPEC_CONFIG
+      });
+    });
+
+    it('should return a spec with the domain that is already set in an Encoding Query', () => {
+      const specM = SpecQueryModel.build(
+        {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encodings: [
+            {channel: Channel.X, field: 'A', type: Type.ORDINAL, scale: {domain: ['L', 'M', 'S']}},
+            {channel: Channel.Y, field: 'B', type: Type.QUANTITATIVE}
+          ]
+        },
+        new Schema({fields:
+          [{
+            name: 'A',
+            vlType: 'ordinal',
+            type: 'string' as any,
+            ordinalDomain: ['S', 'M', 'L'],
+            stats: {
+              distinct: 3
+            }
+          },{
+            name: 'B',
+            vlType: 'quantitative',
+            type: 'number' as any,
+            stats: {
+              distinct: 3
+            }
+          }] as FieldSchema[]
+        }),
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encoding: {
+            x: {field: 'A', type: Type.ORDINAL, scale: {domain: ['L', 'M', 'S']}},
+            y: {field: 'B', type: Type.QUANTITATIVE}
+          },
+          config: DEFAULT_SPEC_CONFIG
+      });
+    });
 
     it('should return a spec with bin as object if the bin has no parameter.', () => {
       const specM = buildSpecQueryModel({
-        data: {values: [{A: 1}]},
+        data: {values: [{Q: 1}]},
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, bin: {maxbins: 50}, field: 'A', type: Type.QUANTITATIVE}
+          {channel: Channel.X, bin: {maxbins: 50}, field: 'Q', type: Type.QUANTITATIVE}
         ]
       });
 
       const spec = specM.toSpec();
       assert.deepEqual(spec, {
-        data: {values: [{A: 1}]},
+        data: {values: [{Q: 1}]},
         mark: Mark.BAR,
         encoding: {
-          x: {bin: {maxbins: 50}, field: 'A', type: Type.QUANTITATIVE}
+          x: {bin: {maxbins: 50}, field: 'Q', type: Type.QUANTITATIVE}
         },
         config: DEFAULT_SPEC_CONFIG
       });
@@ -446,24 +527,24 @@ describe('SpecQueryModel', () => {
 
     it('should return a correct Vega-Lite spec if the query has sort: SortOrder', () => {
       const specM = buildSpecQueryModel({
-        data: {values: [{A: 1, B: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1, O: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, field: 'A', sort: 'ascending', type: Type.QUANTITATIVE},
-          {channel: Channel.Y, field: 'A', sort: {field: 'A', op: 'mean', order: 'ascending'}, type: Type.QUANTITATIVE}
+          {channel: Channel.X, field: 'Q', aggregate: 'mean', type: Type.QUANTITATIVE},
+          {channel: Channel.Y, field: 'O', sort: {field: 'Q', op: 'mean', order: 'ascending'}, type: Type.ORDINAL}
 
         ]
       });
 
       const spec = specM.toSpec();
       assert.deepEqual(spec, {
-        data: {values: [{A: 1}]},
-        transform: [{filter: 'datum.A===1'}],
+        data: {values: [{Q: 1, O: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', sort: 'ascending', type: Type.QUANTITATIVE},
-          y: {field: 'A', sort: {field: 'A', op: 'mean', order: 'ascending'}, type: Type.QUANTITATIVE}
+          x: {field: 'Q', aggregate: 'mean', type: Type.QUANTITATIVE},
+          y: {field: 'O', sort: {field: 'Q', op: 'mean', order: 'ascending'}, type: Type.ORDINAL}
         },
         config: DEFAULT_SPEC_CONFIG
       });
@@ -473,7 +554,7 @@ describe('SpecQueryModel', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, field: 'A', type: Type.ORDINAL},
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL},
           {channel: Channel.Y, autoCount: true, type: Type.QUANTITATIVE}
         ]
       });
@@ -482,7 +563,7 @@ describe('SpecQueryModel', () => {
       assert.deepEqual(spec, {
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', type: Type.ORDINAL},
+          x: {field: 'O', type: Type.ORDINAL},
           y: {aggregate: 'count', field: '*', type: Type.QUANTITATIVE}
         },
         config: DEFAULT_SPEC_CONFIG
@@ -493,7 +574,7 @@ describe('SpecQueryModel', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, field: 'A', type: Type.ORDINAL},
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL},
           {channel: Channel.Y, autoCount: false}
         ]
       });
@@ -502,7 +583,7 @@ describe('SpecQueryModel', () => {
       assert.deepEqual(spec, {
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', type: Type.ORDINAL}
+          x: {field: 'O', type: Type.ORDINAL}
         },
         config: DEFAULT_SPEC_CONFIG
       });
@@ -514,7 +595,7 @@ describe('SpecQueryModel', () => {
       const specM = buildSpecQueryModel({
         mark: Mark.BAR,
         encodings: [
-          {channel: Channel.X, field: 'A', type: Type.ORDINAL},
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL},
           {channel: SHORT_WILDCARD, autoCount: false}
         ]
       });
@@ -523,7 +604,7 @@ describe('SpecQueryModel', () => {
       assert.deepEqual(spec, {
         mark: Mark.BAR,
         encoding: {
-          x: {field: 'A', type: Type.ORDINAL}
+          x: {field: 'O', type: Type.ORDINAL}
         },
         config: DEFAULT_SPEC_CONFIG
       });

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -375,50 +375,6 @@ describe('SpecQueryModel', () => {
     });
 
     it('should return a spec with the domain specified in FieldSchema if the encoding query ' +
-       'did not originaly have scale', () => {
-      const specM = SpecQueryModel.build(
-        {
-          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
-          mark: Mark.BAR,
-          encodings: [
-            {channel: Channel.X, field: 'A', type: Type.ORDINAL},
-            {channel: Channel.Y, field: 'B', type: Type.QUANTITATIVE}
-          ]
-        },
-        new Schema({fields:
-          [{
-            name: 'A',
-            vlType: 'ordinal',
-            type: 'string' as any,
-            ordinalDomain: ['S', 'M', 'L'],
-            stats: {
-              distinct: 3
-            }
-          },{
-            name: 'B',
-            vlType: 'quantitative',
-            type: 'number' as any,
-            stats: {
-              distinct: 3
-            }
-          }] as FieldSchema[]
-        }),
-        DEFAULT_QUERY_CONFIG
-      );
-
-      const spec = specM.toSpec();
-      assert.deepEqual(spec, {
-          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
-          mark: Mark.BAR,
-          encoding: {
-            x: {field: 'A', type: Type.ORDINAL, scale: {domain: ['S', 'M', 'L']}},
-            y: {field: 'B', type: Type.QUANTITATIVE}
-          },
-          config: DEFAULT_SPEC_CONFIG
-      });
-    });
-
-    it('should return a spec with the domain specified in FieldSchema if the encoding query ' +
        'already has scale but does not have domain', () => {
       const specM = SpecQueryModel.build(
         {
@@ -506,8 +462,8 @@ describe('SpecQueryModel', () => {
       });
     });
 
-    it('should return a spec with the domain specified in FieldSchema even if the encoding query ' +
-       'did not originally have a scale', () => {
+    it('should not return a spec with the domain specified in FieldSchema if the encoding query ' +
+       'did not originally have scale', () => {
       const specM = SpecQueryModel.build(
         {
           data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
@@ -543,7 +499,7 @@ describe('SpecQueryModel', () => {
           data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
           mark: Mark.BAR,
           encoding: {
-            x: {field: 'A', type: Type.ORDINAL, scale: {domain: ['S', 'M', 'L']}},
+            x: {field: 'A', type: Type.ORDINAL},
             y: {field: 'B', type: Type.QUANTITATIVE}
           },
           config: DEFAULT_SPEC_CONFIG

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -462,6 +462,94 @@ describe('SpecQueryModel', () => {
       });
     });
 
+    it('should return a spec with the domain specified in FieldSchema if the encoding query ' +
+       'already has scale set to true', () => {
+      const specM = SpecQueryModel.build(
+        {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encodings: [
+            {channel: Channel.X, field: 'A', type: Type.ORDINAL, scale: true},
+            {channel: Channel.Y, field: 'B', type: Type.QUANTITATIVE}
+          ]
+        },
+        new Schema({fields:
+          [{
+            name: 'A',
+            vlType: 'ordinal',
+            type: 'string' as any,
+            ordinalDomain: ['S', 'M', 'L'],
+            stats: {
+              distinct: 3
+            }
+          },{
+            name: 'B',
+            vlType: 'quantitative',
+            type: 'number' as any,
+            stats: {
+              distinct: 3
+            }
+          }] as FieldSchema[]
+        }),
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encoding: {
+            x: {field: 'A', type: Type.ORDINAL, scale: {domain: ['S', 'M', 'L']}},
+            y: {field: 'B', type: Type.QUANTITATIVE}
+          },
+          config: DEFAULT_SPEC_CONFIG
+      });
+    });
+
+    it('should return a spec with the domain specified in FieldSchema even if the encoding query ' +
+       'did not originally have a scale', () => {
+      const specM = SpecQueryModel.build(
+        {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encodings: [
+            {channel: Channel.X, field: 'A', type: Type.ORDINAL},
+            {channel: Channel.Y, field: 'B', type: Type.QUANTITATIVE}
+          ]
+        },
+        new Schema({fields:
+          [{
+            name: 'A',
+            vlType: 'ordinal',
+            type: 'string' as any,
+            ordinalDomain: ['S', 'M', 'L'],
+            stats: {
+              distinct: 3
+            }
+          },{
+            name: 'B',
+            vlType: 'quantitative',
+            type: 'number' as any,
+            stats: {
+              distinct: 3
+            }
+          }] as FieldSchema[]
+        }),
+        DEFAULT_QUERY_CONFIG
+      );
+
+      const spec = specM.toSpec();
+      assert.deepEqual(spec, {
+          data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
+          mark: Mark.BAR,
+          encoding: {
+            x: {field: 'A', type: Type.ORDINAL, scale: {domain: ['S', 'M', 'L']}},
+            y: {field: 'B', type: Type.QUANTITATIVE}
+          },
+          config: DEFAULT_SPEC_CONFIG
+      });
+    });
+
     it('should return a spec with the domain that is already set in an Encoding Query', () => {
       const specM = SpecQueryModel.build(
         {

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -462,8 +462,8 @@ describe('SpecQueryModel', () => {
       });
     });
 
-    it('should not return a spec with the domain specified in FieldSchema if the encoding query ' +
-       'did not originally have scale', () => {
+    it('should return a spec with the domain specified in FieldSchema if the encoding query ' +
+       'scale is undefined', () => {
       const specM = SpecQueryModel.build(
         {
           data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
@@ -499,7 +499,7 @@ describe('SpecQueryModel', () => {
           data: {values: [{A: 'L', B: 4}, {A: 'S', B: 2}, {A: 'M', B: 42}]},
           mark: Mark.BAR,
           encoding: {
-            x: {field: 'A', type: Type.ORDINAL},
+            x: {field: 'A', type: Type.ORDINAL, scale: {domain: ['S', 'M', 'L']}},
             y: {field: 'B', type: Type.QUANTITATIVE}
           },
           config: DEFAULT_SPEC_CONFIG


### PR DESCRIPTION
Part of #87: 

- Add an optional `ordinalDomain` property to the `FieldSchema` for specifying natural order for ordinal data.
- Make `Schema`'s domain() method return `ordinalDomain` when applicable
- Make `SpecQueryMoel.toSpec()` output the value of `ordinalDomain` when applicable