### PR TITLE
Prevent toSpec from outputting with inapplicable scale, sort, axis, legend

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -56,7 +56,7 @@ const ENCODING_NESTED_PROP_PARENTS: EncodingTopLevelProp[] = [
   'bin', 'scale', 'sort', 'axis', 'legend'
 ];
 
-const ENCODING_NESTED_PROP_PARENT_INDEX = toMap(ENCODING_NESTED_PROP_PARENTS);
+export const ENCODING_NESTED_PROP_PARENT_INDEX = toMap(ENCODING_NESTED_PROP_PARENTS);
 
 export function hasNestedProperty(prop: string) {
   return ENCODING_NESTED_PROP_PARENT_INDEX[prop as string];

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -665,6 +665,17 @@ describe('SpecQueryModel', () => {
 
       assert.isNull(specM.toSpec());
     });
+
+    it('should not output spec with inapplicable scale, sort, axis / legend ', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.BAR,
+        encodings: [
+          {channel: Channel.X, bin: {'maxbins': '?'}, field: 'A', type: Type.QUANTITATIVE}
+        ]
+      });
+
+      assert.isNull(specM.toSpec());
+    });
   });
 });
 

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -264,6 +264,24 @@ describe('SpecQueryModel', () => {
   });
 
   describe('toSpec', () => {
+    it('should not return a Vega-Lite spec if an encoding property is wildcard', () => {
+      const specM = buildSpecQueryModel({
+        data: {values: [{Q: 1}]},
+        transform: [{filter: 'datum.Q===1'}],
+        mark: Mark.BAR,
+        encodings: [
+          {
+            channel: Channel.X,
+            field: '?',
+            type: Type.QUANTITATIVE,
+          }
+        ]
+      });
+
+      const spec = specM.toSpec();
+      assert.isNull(spec);
+    });
+
     it('should return a Vega-Lite spec if the query is completed', () => {
       const specM = buildSpecQueryModel({
         data: {values: [{Q: 1}]},


### PR DESCRIPTION
Fix #393 
Prior to this fix, nested properties of scale, sort, axis, legend that are wildcard would be output by toSpec since we blindly copied over the entire encoding property if its parent is not a wildcard. This should not happen since Vega-Lite specs do not contain CQL wildcards. 