### PR TITLE
Export missing Query type

### DIFF
--- a/src/query/index.ts
+++ b/src/query/index.ts
@@ -5,3 +5,4 @@ export import groupBy = require('./groupby');
 export import shorthand = require('./shorthand');
 export import spec = require('./spec');
 export import transform = require('./transform');
+export {Query} from './query';


### PR DESCRIPTION
So one can write in TS

```ts
const query: cql.query.Query = {...}
```

… instead of having to do this:

```ts
import { Query } from "compassql/build/src/query/query";
```
