### PR TITLE
Improve Usage Example in the docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,26 @@
 <html>
 <body>
+From the following query for automatically selecting a mark:
+
+<div><pre id='query'></pre></div>
+
+we get the following Vega-Lite spec:
+
+(See this file's source code for steps to reproduce this!)
+
+<div><pre id='spec'></pre></div>
+
 <script src="./node_modules/d3/build/d3.min.js"></script>
 <script src="./build/compassql.js"/></script>
 <script>
 d3.json('node_modules/vega-datasets/data/cars.json', function(error, data) {
+  // 1) Specify a query config
+  var opt = {};
+
+  // 2) Build a data schema.
+  var schema = cql.schema.build(data, opt);
+
+  // 3) Specify a Query (e.g., a query for automatically selecting a mark)
   var query = {
     "spec": {
       "data": {"url": "node_modules/vega-datasets/data/cars.json"},
@@ -23,17 +40,24 @@ d3.json('node_modules/vega-datasets/data/cars.json', function(error, data) {
     },
     "chooseBy": "effectiveness"
   };
-  var opt = {}; // query config
-  var schema = cql.schema.build(data, opt);
+
+  // 4) Execute a CompassQL `query`.
   var output = cql.recommend(query, schema, opt);
   var result = output.result;
-  // Note: We might improve output of of our API.
-  // Currently, a result is an object of class SpecQueryModelGroup
-  // that can contains items of class SpecQueryModel or SpecQueryModelGroup.
-  // In this case, we don't have groupBy, so it's definitely a SpecQueryModel.
-  // We can convert a SpecQueryModel to a Vega-Lite spec using toSpec() method.
-  console.log(JSON.stringify(result.items[0].toSpec(), null, 2));
-})
+
+  // 5) Convert the result tree of SpecQueryModel into a tree of Vega-Lite specifications.
+  var vlTree = cql.result.mapLeaves(result, function(item) {
+    return item.toSpec();
+  });
+
+  // 6) Use the result.  In this case, the tree has only 2 levels (the root and leaves).
+  // We can just get the top visualization by accessing the 0-th item.
+  var topVlSpec = vlTree.items[0];
+
+  document.querySelector('#query').innerHTML =  JSON.stringify(query, null, 2);
+  document.querySelector('#spec').innerHTML =  JSON.stringify(topVlSpec, null, 2);
+});
 </script>
+
 </body>
 </html>

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -3,13 +3,35 @@ import {Nest, GroupBy} from './groupby';
 import {QueryConfig} from '../config';
 
 export interface Query {
+  /**
+   * **Specification** (`spec`) for describing a collection of queried visualizations. This `spec`'s syntax follows a structure similar to [Vega-Lite](https://vega.github.io/vega-lite)'s single view specification.  However, `spec` in CompassQL can have _wildcards_ (or _enumeration specifiers_) to describe properties that can be enumerated.
+   *
+   * See the SpecQuery interface for more details.
+   */
   spec: SpecQuery;
 
+  /**
+   * Methods for grouping queried visualization into groups.  This property is a shorthand for the `nest` property with one level.
+   */
   groupBy?: GroupBy;
+
+  /**
+   * Methods for grouping queried visualization into hierarchical groupings.
+   */
   nest?: Nest[];
 
+  /**
+   * Method for ordering the list of visualization represented by this query (or the list of visualization groups if `groupBy` or `nest` is specified.)
+   */
   orderBy?: string | string[];
+
+  /**
+   * Method for ordering the top visualization represented by this query (or the top  visualization group if `groupBy` or `nest` is specified.)
+   */
   chooseBy?: string | string[];
 
+  /**
+   * Configuration for customizing query parameters.
+   */
   config?: QueryConfig;
 }

--- a/src/query/query.ts
+++ b/src/query/query.ts
@@ -4,14 +4,18 @@ import {QueryConfig} from '../config';
 
 export interface Query {
   /**
-   * **Specification** (`spec`) for describing a collection of queried visualizations. This `spec`'s syntax follows a structure similar to [Vega-Lite](https://vega.github.io/vega-lite)'s single view specification.  However, `spec` in CompassQL can have _wildcards_ (or _enumeration specifiers_) to describe properties that can be enumerated.
+   * **Specification** (`spec`) for describing a collection of queried visualizations. This `spec`'s 
+   * syntax follows a structure similar to [Vega-Lite](https://vega.github.io/vega-lite)'s single view 
+   * specification.  However, `spec` in CompassQL can have _wildcards_ (or _enumeration specifiers_) 
+   * to describe properties that can be enumerated.
    *
    * See the SpecQuery interface for more details.
    */
   spec: SpecQuery;
 
   /**
-   * Methods for grouping queried visualization into groups.  This property is a shorthand for the `nest` property with one level.
+   * Methods for grouping queried visualization into groups.  This property is a shorthand for the 
+   * `nest` property with one level.
    */
   groupBy?: GroupBy;
 
@@ -21,12 +25,14 @@ export interface Query {
   nest?: Nest[];
 
   /**
-   * Method for ordering the list of visualization represented by this query (or the list of visualization groups if `groupBy` or `nest` is specified.)
+   * Method for ordering the list of visualization represented by this query (or the list of visualization 
+   * groups if `groupBy` or `nest` is specified.)
    */
   orderBy?: string | string[];
 
   /**
-   * Method for ordering the top visualization represented by this query (or the top  visualization group if `groupBy` or `nest` is specified.)
+   * Method for ordering the top visualization represented by this query (or the top  visualization group 
+   * if `groupBy` or `nest` is specified.)
    */
   chooseBy?: string | string[];
 

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -14,22 +14,27 @@ import {TopLevel, FacetedCompositeUnitSpec} from 'vega-lite/build/src/spec';
 import {toMap} from 'datalib/src/util';
 
 /**
- * This interface follows the same structure as [Vega-Lite](https://github.com/vega/vega-lite)'s `UnitSpec`.
- * The interface name has `Query` suffixes to hint that its instance (which can contain wildcards) is a query that describe a collection of specifications.
- *
- * Most interfaces under `SpecQuery` similarly describe a "query" version of directives in Vega-Lite.
- * One thing that is different is that `encodings` here is an array that describes encoding queries while `encoding` in Vega-Lite is an object.
- * The reason is that channels in CQL can be wildcards.
- * And if you have multiple wildcards, it can't be a dictionary object. So we flatten it.
- *
+ * A "query" version of a [Vega-Lite](https://github.com/vega/vega-lite)'s `UnitSpec` (single view specification).
+ * This interface and most of  its children have `Query` suffixes to hint that their instanced are queries that can contain wildcards to describe a collection of specifications.
  */
 export interface SpecQuery {
   data?: Data;
+
+  // TODO: support mark definition object
   mark: WildcardProperty<Mark>;
   transform?: TransformQuery[];
+
+  /**
+   * Array of encoding query mappings.
+   * Note: Vega-Lite's `encoding` is an object whose keys are unique encoding channels.
+   * However, for CompassQL, the `channel` property of encoding query mappings can be wildcards. Thus the `encoding` object in Vega-Lite is flatten as the `encodings` array in CompassQL.
+   */
   encodings: EncodingQuery[];
 
   // TODO: make config query (not important at all, only for the sake of completeness.)
+  /**
+   * Vega-Lite Configuration
+   */
   config?: Config;
 }
 

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -15,7 +15,8 @@ import {toMap} from 'datalib/src/util';
 
 /**
  * A "query" version of a [Vega-Lite](https://github.com/vega/vega-lite)'s `UnitSpec` (single view specification).
- * This interface and most of  its children have `Query` suffixes to hint that their instanced are queries that can contain wildcards to describe a collection of specifications.
+ * This interface and most of  its children have `Query` suffixes to hint that their instanced are queries that 
+ * can contain wildcards to describe a collection of specifications.
  */
 export interface SpecQuery {
   data?: Data;
@@ -27,7 +28,8 @@ export interface SpecQuery {
   /**
    * Array of encoding query mappings.
    * Note: Vega-Lite's `encoding` is an object whose keys are unique encoding channels.
-   * However, for CompassQL, the `channel` property of encoding query mappings can be wildcards. Thus the `encoding` object in Vega-Lite is flatten as the `encodings` array in CompassQL.
+   * However, for CompassQL, the `channel` property of encoding query mappings can be wildcards. 
+   * Thus the `encoding` object in Vega-Lite is flatten as the `encodings` array in CompassQL.
    */
   encodings: EncodingQuery[];
 

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -75,7 +75,7 @@ export interface TableSchema<F extends TableSchemaFieldDescriptor> {
  *
  * @return a Schema object
  */
-export function build(data: any,  tableSchema: TableSchema<TableSchemaFieldDescriptor> = {fields:[]}, opt: QueryConfig = {}): Schema {
+export function build(data: any, opt: QueryConfig = {}, tableSchema: TableSchema<TableSchemaFieldDescriptor> = {fields:[]}): Schema {
   opt = extend({}, DEFAULT_QUERY_CONFIG, opt);
 
   // create profiles for each variable

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -81,7 +81,7 @@ describe('schema', () => {
       for (let i = 0; i < configWithOrdinalInference.numberOrdinalLimit + 1; i++) {
         numberData.push({a: i});
       }
-      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
+      const numberSchema = build(numberData, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.QUANTITATIVE);
     });
 
@@ -92,7 +92,7 @@ describe('schema', () => {
       for (let i = 0; i < total; i++) {
         numberData.push({a: 1});
       }
-      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
+      const numberSchema = build(numberData, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
 
@@ -106,7 +106,7 @@ describe('schema', () => {
         numberData.push({a: 1});
         numberData.push({a: 2});
       }
-      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
+      const numberSchema = build(numberData, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
 
@@ -120,7 +120,7 @@ describe('schema', () => {
         numberData.push({a: 2});
         numberData.push({a: 3});
       }
-      const numberSchema = build(numberData, {fields:[]}, configWithOrdinalInference);
+      const numberSchema = build(numberData, configWithOrdinalInference);
       assert.equal(numberSchema.vlType('a'), Type.NOMINAL);
     });
   });
@@ -537,7 +537,7 @@ describe('schema', () => {
     };
 
     // build schema with passed in dataTable schema
-    let dataTableSchema: Schema = build(dataTableData, dataTable);
+    let dataTableSchema: Schema = build(dataTableData, {}, dataTable);
 
     it('should have data table schema values override inferred values', () => {
       assert.equal(dataTableSchema.primitiveType('b'), PrimitiveType.INTEGER);


### PR DESCRIPTION
@haldenl I tried to improve the documentation. Please help review.

You can just look at the "more detailed docs" commit as the other commit is from https://github.com/vega/compassql/pull/412. 


Note that in https://github.com/vega/compassql/pull/411, I also added a `mapLeaves` method which can be useful for your "generate example" script.  

cc: @arjun010  