### PR TITLE
Add width/height as a top level specification for CQL queries.

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -286,6 +286,14 @@ export class SpecQueryModel {
 
     spec.mark = this._spec.mark as Mark;
     spec.encoding = toEncoding(this.specQuery.encodings, {schema: this._schema, wildcardMode: 'null'});
+
+    if (this._spec.width) {
+      spec.width = this._spec.width;
+    }
+    if (this._spec.height) {
+      spec.height = this._spec.height;
+    }
+
     if (spec.encoding === null) {
       return null;
     }

--- a/src/property.ts
+++ b/src/property.ts
@@ -16,10 +16,11 @@ import {Diff} from './util';
  * Another is an object that describes a parent property (e.g., `scale`) and the child property (e.g., `type`)
  */
 export type Property = FlatProp | EncodingNestedProp;
-export type FlatProp = MarkProp | TransformProp | EncodingTopLevelProp;
+export type FlatProp = MarkProp | TransformProp | SizeProp | EncodingTopLevelProp;
 
 export type MarkProp = 'mark' | 'stack'; // FIXME: determine how 'stack' works;
 export type TransformProp = keyof TransformQuery;
+export type SizeProp = 'width' | 'height';
 export type EncodingTopLevelProp = Diff<keyof (FieldQuery & ValueQuery & AutoCountQuery), 'description'>; // Do not include description since description is simply a metadata
 
 export type EncodingNestedProp = BinProp | SortProp | ScaleProp | AxisProp | LegendProp;
@@ -101,6 +102,8 @@ export const ENCODING_NESTED_PROPS = ([] as EncodingNestedProp[]).concat(
   BIN_PROPS, SORT_PROPS, SCALE_PROPS, AXIS_PROPS, LEGEND_PROPS
 );
 
+export const SIZE_PROPS: Property[] = ['width', 'height'] as Property[];
+
 const PROP_KEY_DELIMITER = '.';
 
 export function toKey(p: Property): string {
@@ -160,7 +163,10 @@ export const DEFAULT_PROP_PRECEDENCE: Property[] =
   'mark', // 'stack',
 
   'scale', 'sort',
-  'axis', 'legend'
+  'axis', 'legend',
+
+  // size
+  'width', 'height'
 ] as Property[]).concat(
   BIN_PROPS, SCALE_PROPS, AXIS_PROPS, LEGEND_PROPS, SORT_PROPS
 );
@@ -190,4 +196,7 @@ export namespace Property {
   export const AXIS: 'axis' = 'axis';
 
   export const LEGEND: 'legend' = 'legend';
+
+  export const WIDTH: 'width' = 'width';
+  export const HEIGHT: 'height' = 'height';
 }

--- a/src/property.ts
+++ b/src/property.ts
@@ -163,10 +163,7 @@ export const DEFAULT_PROP_PRECEDENCE: Property[] =
   'mark', // 'stack',
 
   'scale', 'sort',
-  'axis', 'legend',
-
-  // size
-  'width', 'height'
+  'axis', 'legend'
 ] as Property[]).concat(
   BIN_PROPS, SCALE_PROPS, AXIS_PROPS, LEGEND_PROPS, SORT_PROPS
 );

--- a/src/property.ts
+++ b/src/property.ts
@@ -163,7 +163,7 @@ export const DEFAULT_PROP_PRECEDENCE: Property[] =
   'mark', // 'stack',
 
   'scale', 'sort',
-  'axis', 'legend'
+  'axis', 'legend',
 ] as Property[]).concat(
   BIN_PROPS, SCALE_PROPS, AXIS_PROPS, LEGEND_PROPS, SORT_PROPS
 );

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -8,7 +8,7 @@ import {isString} from 'datalib/src/util';
 import {EncodingQuery, isFieldQuery, FieldQuery, isValueQuery, isDisabledAutoCountQuery, isEnabledAutoCountQuery, isAutoCountQuery, FieldQueryBase} from './encoding';
 import {SpecQuery, stack, fromSpec} from './spec';
 import {isWildcard, isShortWildcard, SHORT_WILDCARD} from '../wildcard';
-import {getEncodingNestedProp, Property, isEncodingNestedParent, DEFAULT_PROP_PRECEDENCE, SORT_PROPS, EncodingNestedChildProp} from '../property';
+import {getEncodingNestedProp, Property, isEncodingNestedParent, DEFAULT_PROP_PRECEDENCE, SIZE_PROPS, SORT_PROPS, EncodingNestedChildProp} from '../property';
 import {PropIndex} from '../propindex';
 import {Dict, keys, isArray, isBoolean} from '../util';
 
@@ -134,11 +134,10 @@ export function spec(specQ: SpecQuery,
     }
   }
 
-  if (!!specQ.width) {
-    parts.push(`width=${specQ.width}`);
-  }
-  if (!!specQ.height) {
-    parts.push(`height=${specQ.height}`);
+  for (let sizeProp of SIZE_PROPS) {
+    if (include.get(sizeProp)) {
+      parts.push(`${sizeProp}=${specQ[sizeProp as string]}`);
+    }
   }
 
   return parts.join('|');

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -136,9 +136,9 @@ export function spec(specQ: SpecQuery,
   }
 
   for (let sizeProp of SIZE_PROPS) {
-    const prop = sizeProp.toString();
-    if (include.get(sizeProp) && !!specQ[prop]) {
-      parts.push(`${prop}=${specQ[prop]}`);
+    const propString = sizeProp.toString();
+    if (include.get(sizeProp) && !!specQ[propString]) {
+      parts.push(`${propString}=${specQ[propString]}`);
     }
   }
 

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -134,6 +134,13 @@ export function spec(specQ: SpecQuery,
     }
   }
 
+  if (!!specQ.width) {
+    parts.push(`width=${specQ.width}`);
+  }
+  if (!!specQ.height) {
+    parts.push(`height=${specQ.height}`);
+  }
+
   return parts.join('|');
 }
 

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -56,7 +56,8 @@ export const INCLUDE_ALL: PropIndex<boolean> =
   [].concat(
     DEFAULT_PROP_PRECEDENCE,
     SORT_PROPS,
-    [Property.TRANSFORM, Property.STACK]
+    [Property.TRANSFORM, Property.STACK],
+    SIZE_PROPS
   )
   .reduce((pi, prop: Property) => pi.set(prop, true), new PropIndex<boolean>());
 
@@ -135,8 +136,9 @@ export function spec(specQ: SpecQuery,
   }
 
   for (let sizeProp of SIZE_PROPS) {
-    if (include.get(sizeProp) && !!specQ[sizeProp as string]) {
-      parts.push(`${sizeProp}=${specQ[sizeProp as string]}`);
+    const prop = sizeProp.toString();
+    if (include.get(sizeProp) && !!specQ[prop]) {
+      parts.push(`${prop}=${specQ[prop]}`);
     }
   }
 

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -135,7 +135,7 @@ export function spec(specQ: SpecQuery,
   }
 
   for (let sizeProp of SIZE_PROPS) {
-    if (include.get(sizeProp)) {
+    if (include.get(sizeProp) && !!specQ[sizeProp as string]) {
       parts.push(`${sizeProp}=${specQ[sizeProp as string]}`);
     }
   }

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -34,9 +34,13 @@ export interface SpecQuery {
   encodings: EncodingQuery[];
 
   /**
-   * Width and height
+   * The width of the resulting encodings, does not support wildcards.
    */
   width?: number;
+
+  /**
+   * The height of the resulting encodings, does not support wildcards.
+   */
   height?: number;
 
   // TODO: make config query (not important at all, only for the sake of completeness.)

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -15,7 +15,7 @@ import {toMap} from 'datalib/src/util';
 
 /**
  * A "query" version of a [Vega-Lite](https://github.com/vega/vega-lite)'s `UnitSpec` (single view specification).
- * This interface and most of  its children have `Query` suffixes to hint that their instanced are queries that 
+ * This interface and most of  its children have `Query` suffixes to hint that their instanced are queries that
  * can contain wildcards to describe a collection of specifications.
  */
 export interface SpecQuery {
@@ -28,10 +28,16 @@ export interface SpecQuery {
   /**
    * Array of encoding query mappings.
    * Note: Vega-Lite's `encoding` is an object whose keys are unique encoding channels.
-   * However, for CompassQL, the `channel` property of encoding query mappings can be wildcards. 
+   * However, for CompassQL, the `channel` property of encoding query mappings can be wildcards.
    * Thus the `encoding` object in Vega-Lite is flatten as the `encodings` array in CompassQL.
    */
   encodings: EncodingQuery[];
+
+  /**
+   * Width and height
+   */
+  width?: number;
+  height?: number;
 
   // TODO: make config query (not important at all, only for the sake of completeness.)
   /**
@@ -49,6 +55,8 @@ export function fromSpec(spec: TopLevel<FacetedCompositeUnitSpec>): SpecQuery {
   return extend(
     spec.data ? { data: spec.data} : {},
     spec.transform ? { transform: spec.transform } : {},
+    spec.width ? { width: spec.width } : {},
+    spec.height ? { height: spec.height } : {},
     {
       mark: spec.mark,
       encodings: keys(spec.encoding).map((channel: Channel) => {

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -34,12 +34,14 @@ export interface SpecQuery {
   encodings: EncodingQuery[];
 
   /**
-   * The width of the resulting encodings, does not support wildcards.
+   * The width of the resulting encodings.
+   * __NOTE:__ Does not support wildcards.
    */
   width?: number;
 
   /**
-   * The height of the resulting encodings, does not support wildcards.
+   * The height of the resulting encodings.
+   * __NOTE:__ Does not support wildcards.
    */
   height?: number;
 

--- a/src/wildcardindex.ts
+++ b/src/wildcardindex.ts
@@ -1,9 +1,8 @@
 import {Mark} from 'vega-lite/build/src/mark';
 
 import {Wildcard} from './wildcard';
-import {Property, isEncodingProperty, SIZE_PROPS} from './property';
+import {Property, isEncodingProperty} from './property';
 import {PropIndex} from './propindex';
-import {contains} from './util';
 
 
 export interface EncodingsWildcardIndex {
@@ -51,8 +50,6 @@ export class WildcardIndex {
       return this.encodingIndicesByProperty.has(prop);
     } else if (prop === 'mark') {
       return !!this.mark;
-    } else if (contains(SIZE_PROPS, prop)) {
-      return !!this[prop];
     }
     /* istanbul ignore next */
     throw new Error('Unimplemented for property ' + prop);

--- a/src/wildcardindex.ts
+++ b/src/wildcardindex.ts
@@ -1,8 +1,9 @@
 import {Mark} from 'vega-lite/build/src/mark';
 
 import {Wildcard} from './wildcard';
-import {Property, isEncodingProperty} from './property';
+import {Property, isEncodingProperty, SIZE_PROPS} from './property';
 import {PropIndex} from './propindex';
+import {contains} from './util';
 
 
 export interface EncodingsWildcardIndex {
@@ -48,8 +49,10 @@ export class WildcardIndex {
   public hasProperty(prop: Property) {
     if (isEncodingProperty(prop)) {
       return this.encodingIndicesByProperty.has(prop);
-    } if (prop === 'mark') {
+    } else if (prop === 'mark') {
       return !!this.mark;
+    } else if (contains(SIZE_PROPS, prop)) {
+      return !!this[prop];
     }
     /* istanbul ignore next */
     throw new Error('Unimplemented for property ' + prop);

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -692,6 +692,20 @@ describe('SpecQueryModel', () => {
 
       assert.isNull(specM.toSpec());
     });
+
+    it('should return a spec with width and height specified', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.BAR,
+        width: 100,
+        height: 120,
+        encodings: [
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL}
+        ]
+      });
+
+      assert.equal(specM.toSpec().width, 100);
+      assert.equal(specM.toSpec().height, 120);
+    });
   });
 });
 

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -799,4 +799,40 @@ describe('query/shorthand', () => {
        assert.equal(str, 'a,?');
     });
   });
+
+  describe('width and height', () => {
+    it('should return correct shorthand string for width in a SpecQuery', () => {
+      const str = specShorthand({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: Channel.X, field: 'a', type: Type.QUANTITATIVE}
+        ],
+        width: 1440
+      });
+      assert.equal(str, 'point|x:a,q|width=1440');
+    });
+
+    it('should return correct shorthand string for height in a SpecQuery', () => {
+      const str = specShorthand({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: Channel.X, field: 'a', type: Type.QUANTITATIVE}
+        ],
+        height: 1080
+      });
+      assert.equal(str, 'point|x:a,q|height=1080');
+    });
+
+    it('should return correct shorthand string for width and height in a SpecQuery', () => {
+      const str = specShorthand({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: Channel.X, field: 'a', type: Type.QUANTITATIVE}
+        ],
+        width: 1440,
+        height: 1080
+      });
+      assert.equal(str, 'point|x:a,q|width=1440|height=1080');
+    });
+  });
 });

--- a/test/query/shorthand.test.ts
+++ b/test/query/shorthand.test.ts
@@ -834,5 +834,17 @@ describe('query/shorthand', () => {
       });
       assert.equal(str, 'point|x:a,q|width=1440|height=1080');
     });
+
+    it('should omit width and height from shorthand string if they are not in include', () => {
+      const str = specShorthand({
+        mark: Mark.POINT,
+        encodings: [
+          {channel: Channel.X, field: 'a', type: Type.QUANTITATIVE}
+        ],
+        width: 1440,
+        height: 1080
+      }, INCLUDE_ALL.duplicate().set('width', false).set('height', false));
+      assert.equal(str, 'point|x:a,q');
+    });
   });
 });


### PR DESCRIPTION
Width height can be specified to control the dimensions of the output vega-lite specs that come out of `recommend`. See issue #332 

