### PR TITLE
Add support for remaining top level props

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -296,6 +296,9 @@ export class SpecQueryModel {
     if (this._spec.background) {
       spec.background = this._spec.background;
     }
+    if (this._spec.padding) {
+      spec.padding = this._spec.padding;
+    }
     if(this._spec.title) {
       spec.title = this._spec.title;
     }

--- a/src/model.ts
+++ b/src/model.ts
@@ -293,6 +293,9 @@ export class SpecQueryModel {
     if (this._spec.height) {
       spec.height = this._spec.height;
     }
+    if(this._spec.title) {
+      spec.title = this._spec.title;
+    }
 
     if (spec.encoding === null) {
       return null;

--- a/src/model.ts
+++ b/src/model.ts
@@ -2,7 +2,7 @@ import {Channel} from 'vega-lite/build/src/channel';
 import {Data} from 'vega-lite/build/src/data';
 import {Mark} from 'vega-lite/build/src/mark';
 import {Type} from 'vega-lite/build/src/type';
-import {FacetedCompositeUnitSpec} from 'vega-lite/build/src/spec';
+import {TopLevel, FacetedCompositeUnitSpec} from 'vega-lite/build/src/spec';
 import {StackProperties} from 'vega-lite/build/src/stack';
 import {QueryConfig} from './config';
 import {Property, ENCODING_TOPLEVEL_PROPS, ENCODING_NESTED_PROPS, isEncodingNestedProp, isEncodingNestedParent} from './property';
@@ -271,7 +271,7 @@ export class SpecQueryModel {
    * Convert a query to a Vega-Lite spec if it is completed.
    * @return a Vega-Lite spec if completed, null otherwise.
    */
-  public toSpec(data?: Data): FacetedCompositeUnitSpec {
+  public toSpec(data?: Data): TopLevel<FacetedCompositeUnitSpec> {
     if (isWildcard(this._spec.mark)) return null;
 
     let spec: any = {};
@@ -292,6 +292,9 @@ export class SpecQueryModel {
     }
     if (this._spec.height) {
       spec.height = this._spec.height;
+    }
+    if (this._spec.background) {
+      spec.background = this._spec.background;
     }
     if(this._spec.title) {
       spec.title = this._spec.title;

--- a/src/property.ts
+++ b/src/property.ts
@@ -20,7 +20,7 @@ export type FlatProp = MarkProp | TransformProp | ViewProp | EncodingTopLevelPro
 
 export type MarkProp = 'mark' | 'stack'; // FIXME: determine how 'stack' works;
 export type TransformProp = keyof TransformQuery;
-export type ViewProp = 'width' | 'height' | 'background' | 'title';
+export type ViewProp = 'width' | 'height' | 'background' | 'padding' | 'title';
 export type EncodingTopLevelProp = Diff<keyof (FieldQuery & ValueQuery & AutoCountQuery), 'description'>; // Do not include description since description is simply a metadata
 
 export type EncodingNestedProp = BinProp | SortProp | ScaleProp | AxisProp | LegendProp;
@@ -102,7 +102,7 @@ export const ENCODING_NESTED_PROPS = ([] as EncodingNestedProp[]).concat(
   BIN_PROPS, SORT_PROPS, SCALE_PROPS, AXIS_PROPS, LEGEND_PROPS
 );
 
-export const VIEW_PROPS: Property[] = ['width', 'height', 'background', 'title'] as Property[];
+export const VIEW_PROPS: Property[] = ['width', 'height', 'background', 'padding', 'title'] as Property[];
 
 const PROP_KEY_DELIMITER = '.';
 
@@ -197,5 +197,6 @@ export namespace Property {
   export const WIDTH: 'width' = 'width';
   export const HEIGHT: 'height' = 'height';
   export const BACKGROUND: 'background' = 'background';
+  export const PADDING: 'padding' = 'padding';
   export const TITLE: 'title' = 'title';
 }

--- a/src/property.ts
+++ b/src/property.ts
@@ -20,7 +20,7 @@ export type FlatProp = MarkProp | TransformProp | ViewProp | EncodingTopLevelPro
 
 export type MarkProp = 'mark' | 'stack'; // FIXME: determine how 'stack' works;
 export type TransformProp = keyof TransformQuery;
-export type ViewProp = 'width' | 'height' | 'title';
+export type ViewProp = 'width' | 'height' | 'background' | 'title';
 export type EncodingTopLevelProp = Diff<keyof (FieldQuery & ValueQuery & AutoCountQuery), 'description'>; // Do not include description since description is simply a metadata
 
 export type EncodingNestedProp = BinProp | SortProp | ScaleProp | AxisProp | LegendProp;
@@ -102,7 +102,7 @@ export const ENCODING_NESTED_PROPS = ([] as EncodingNestedProp[]).concat(
   BIN_PROPS, SORT_PROPS, SCALE_PROPS, AXIS_PROPS, LEGEND_PROPS
 );
 
-export const VIEW_PROPS: Property[] = ['width', 'height', 'title'] as Property[];
+export const VIEW_PROPS: Property[] = ['width', 'height', 'background', 'title'] as Property[];
 
 const PROP_KEY_DELIMITER = '.';
 
@@ -196,5 +196,6 @@ export namespace Property {
 
   export const WIDTH: 'width' = 'width';
   export const HEIGHT: 'height' = 'height';
+  export const BACKGROUND: 'background' = 'background';
   export const TITLE: 'title' = 'title';
 }

--- a/src/property.ts
+++ b/src/property.ts
@@ -16,11 +16,11 @@ import {Diff} from './util';
  * Another is an object that describes a parent property (e.g., `scale`) and the child property (e.g., `type`)
  */
 export type Property = FlatProp | EncodingNestedProp;
-export type FlatProp = MarkProp | TransformProp | SizeProp | EncodingTopLevelProp;
+export type FlatProp = MarkProp | TransformProp | ViewProp | EncodingTopLevelProp;
 
 export type MarkProp = 'mark' | 'stack'; // FIXME: determine how 'stack' works;
 export type TransformProp = keyof TransformQuery;
-export type SizeProp = 'width' | 'height';
+export type ViewProp = 'width' | 'height' | 'title';
 export type EncodingTopLevelProp = Diff<keyof (FieldQuery & ValueQuery & AutoCountQuery), 'description'>; // Do not include description since description is simply a metadata
 
 export type EncodingNestedProp = BinProp | SortProp | ScaleProp | AxisProp | LegendProp;
@@ -102,7 +102,7 @@ export const ENCODING_NESTED_PROPS = ([] as EncodingNestedProp[]).concat(
   BIN_PROPS, SORT_PROPS, SCALE_PROPS, AXIS_PROPS, LEGEND_PROPS
 );
 
-export const SIZE_PROPS: Property[] = ['width', 'height'] as Property[];
+export const VIEW_PROPS: Property[] = ['width', 'height', 'title'] as Property[];
 
 const PROP_KEY_DELIMITER = '.';
 
@@ -196,4 +196,5 @@ export namespace Property {
 
   export const WIDTH: 'width' = 'width';
   export const HEIGHT: 'height' = 'height';
+  export const TITLE: 'title' = 'title';
 }

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -138,7 +138,7 @@ export function spec(specQ: SpecQuery,
   for (let viewProp of VIEW_PROPS) {
     const propString = viewProp.toString();
     if (include.get(viewProp) && !!specQ[propString]) {
-      parts.push(`${propString}=${specQ[propString]}`);
+      parts.push(`${propString}=${JSON.stringify(specQ[propString])}`);
     }
   }
 

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -8,7 +8,7 @@ import {isString} from 'datalib/src/util';
 import {EncodingQuery, isFieldQuery, FieldQuery, isValueQuery, isDisabledAutoCountQuery, isEnabledAutoCountQuery, isAutoCountQuery, FieldQueryBase} from './encoding';
 import {SpecQuery, stack, fromSpec} from './spec';
 import {isWildcard, isShortWildcard, SHORT_WILDCARD} from '../wildcard';
-import {getEncodingNestedProp, Property, isEncodingNestedParent, DEFAULT_PROP_PRECEDENCE, SIZE_PROPS, SORT_PROPS, EncodingNestedChildProp} from '../property';
+import {getEncodingNestedProp, Property, isEncodingNestedParent, DEFAULT_PROP_PRECEDENCE, VIEW_PROPS, SORT_PROPS, EncodingNestedChildProp} from '../property';
 import {PropIndex} from '../propindex';
 import {Dict, keys, isArray, isBoolean} from '../util';
 
@@ -57,7 +57,7 @@ export const INCLUDE_ALL: PropIndex<boolean> =
     DEFAULT_PROP_PRECEDENCE,
     SORT_PROPS,
     [Property.TRANSFORM, Property.STACK],
-    SIZE_PROPS
+    VIEW_PROPS
   )
   .reduce((pi, prop: Property) => pi.set(prop, true), new PropIndex<boolean>());
 
@@ -135,9 +135,9 @@ export function spec(specQ: SpecQuery,
     }
   }
 
-  for (let sizeProp of SIZE_PROPS) {
-    const propString = sizeProp.toString();
-    if (include.get(sizeProp) && !!specQ[propString]) {
+  for (let viewProp of VIEW_PROPS) {
+    const propString = viewProp.toString();
+    if (include.get(viewProp) && !!specQ[propString]) {
       parts.push(`${propString}=${specQ[propString]}`);
     }
   }

--- a/src/query/shorthand.ts
+++ b/src/query/shorthand.ts
@@ -138,7 +138,8 @@ export function spec(specQ: SpecQuery,
   for (let viewProp of VIEW_PROPS) {
     const propString = viewProp.toString();
     if (include.get(viewProp) && !!specQ[propString]) {
-      parts.push(`${propString}=${JSON.stringify(specQ[propString])}`);
+      const value = specQ[propString];
+      parts.push(`${propString}=${JSON.stringify(value)}`);
     }
   }
 

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -45,6 +45,11 @@ export interface SpecQuery {
    */
   height?: number;
 
+  /**
+   * Title for the plot.
+   */
+  title?: string;
+
   // TODO: make config query (not important at all, only for the sake of completeness.)
   /**
    * Vega-Lite Configuration
@@ -63,6 +68,7 @@ export function fromSpec(spec: TopLevel<FacetedCompositeUnitSpec>): SpecQuery {
     spec.transform ? { transform: spec.transform } : {},
     spec.width ? { width: spec.width } : {},
     spec.height ? { height: spec.height } : {},
+    spec.title ? { title: spec.title } : {},
     {
       mark: spec.mark,
       encodings: keys(spec.encoding).map((channel: Channel) => {

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -53,6 +53,16 @@ export interface SpecQuery {
   background?: string;
 
   /**
+   * The default visualization padding, in pixels, from the edge of the
+   * visualization canvas to the data rectangle. If a number, specifies
+   * padding for all sides. If an object, the value should have the
+   * format {"left": 5, "top": 5, "right": 5, "bottom": 5}
+   * to specify padding for each side of the visualization.
+   * __NOTE:__ Does not support wildcards.
+   */
+  padding?: number | Object;
+
+  /**
    * Title for the plot.
    * __NOTE:__ Does not support wildcards.
    */
@@ -76,6 +86,7 @@ export function fromSpec(spec: TopLevel<FacetedCompositeUnitSpec>): SpecQuery {
     spec.transform ? { transform: spec.transform } : {},
     spec.width ? { width: spec.width } : {},
     spec.height ? { height: spec.height } : {},
+    spec.background ? { background: spec.background } : {},
     spec.title ? { title: spec.title } : {},
     {
       mark: spec.mark,

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -58,6 +58,7 @@ export interface SpecQuery {
    * padding for all sides. If an object, the value should have the
    * format {"left": 5, "top": 5, "right": 5, "bottom": 5}
    * to specify padding for each side of the visualization.
+   *
    * __NOTE:__ Does not support wildcards.
    */
   padding?: number | Object;

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -3,6 +3,7 @@ import {Config} from 'vega-lite/build/src/config';
 import {Data} from 'vega-lite/build/src/data';
 import {Mark} from 'vega-lite/build/src/mark';
 import {StackProperties} from 'vega-lite/build/src/stack';
+import {TitleParams} from 'vega-lite/build/src/title';
 
 import {isWildcard, WildcardProperty, Wildcard} from '../wildcard';
 import {isEncodingTopLevelProperty, Property, toKey, FlatProp, EncodingNestedProp} from '../property';
@@ -55,7 +56,7 @@ export interface SpecQuery {
    * Title for the plot.
    * __NOTE:__ Does not support wildcards.
    */
-  title?: string;
+  title?: string | TitleParams;
 
   // TODO: make config query (not important at all, only for the sake of completeness.)
   /**

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -87,6 +87,7 @@ export function fromSpec(spec: TopLevel<FacetedCompositeUnitSpec>): SpecQuery {
     spec.width ? { width: spec.width } : {},
     spec.height ? { height: spec.height } : {},
     spec.background ? { background: spec.background } : {},
+    spec.padding ? { padding: spec.padding } : {},
     spec.title ? { title: spec.title } : {},
     {
       mark: spec.mark,

--- a/src/query/spec.ts
+++ b/src/query/spec.ts
@@ -46,7 +46,14 @@ export interface SpecQuery {
   height?: number;
 
   /**
+   * CSS color property to use as the background of visualization.
+   * __NOTE:__ Does not support wildcards.
+   */
+  background?: string;
+
+  /**
    * Title for the plot.
+   * __NOTE:__ Does not support wildcards.
    */
   title?: string;
 

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -707,6 +707,18 @@ describe('SpecQueryModel', () => {
       assert.equal(specM.toSpec().height, 120);
     });
 
+    it('should return a spec with background color as specified', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.BAR,
+        background: 'black',
+        encodings: [
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL}
+        ]
+      });
+
+      assert.equal(specM.toSpec().background, 'black');
+    });
+
     it('should return a spec with a title specified', () => {
       const specM = buildSpecQueryModel({
         title: 'Big Title',

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -720,6 +720,21 @@ describe('SpecQueryModel', () => {
       assert.equal(specM.toSpec().background, 'black');
     });
 
+    it('should return a spec with padding as specified', () => {
+      const specM = buildSpecQueryModel({
+        mark: Mark.BAR,
+        padding: {
+          left: 1, top: 2, right: 3, bottom: 4
+        },
+        encodings: [
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL}
+        ]
+      });
+
+      assert.deepEqual(specM.toSpec().padding,
+                       { left: 1, top: 2, right: 3, bottom: 4 });
+    });
+
     it('should return a spec with a title string specified', () => {
       const specM = buildSpecQueryModel({
         title: 'Big Title',

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -2,6 +2,7 @@ import {assert} from 'chai';
 import {Channel} from 'vega-lite/build/src/channel';
 import {Mark} from 'vega-lite/build/src/mark';
 import {Type} from 'vega-lite/build/src/type';
+import {TitleParams} from 'vega-lite/build/src/title';
 import {schema} from './fixture';
 import {DEFAULT_QUERY_CONFIG} from '../src/config';
 import {SpecQueryModel, SpecQueryModelGroup} from '../src/model';
@@ -719,7 +720,7 @@ describe('SpecQueryModel', () => {
       assert.equal(specM.toSpec().background, 'black');
     });
 
-    it('should return a spec with a title specified', () => {
+    it('should return a spec with a title string specified', () => {
       const specM = buildSpecQueryModel({
         title: 'Big Title',
         mark: Mark.BAR,
@@ -729,6 +730,23 @@ describe('SpecQueryModel', () => {
       });
 
       assert.equal(specM.toSpec().title, 'Big Title');
+    });
+
+    it('should return a spec with a title params specified', () => {
+      const specM = buildSpecQueryModel({
+        title: {
+          text: 'A Simple Bar Chart',
+          anchor: 'start'
+        },
+        mark: Mark.BAR,
+        encodings: [
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL}
+        ]
+      });
+
+      const title = specM.toSpec().title as TitleParams;
+      assert.equal(title.text, 'A Simple Bar Chart');
+      assert.equal(title.anchor, 'start');
     });
   });
 });

--- a/test/model.test.ts
+++ b/test/model.test.ts
@@ -706,6 +706,18 @@ describe('SpecQueryModel', () => {
       assert.equal(specM.toSpec().width, 100);
       assert.equal(specM.toSpec().height, 120);
     });
+
+    it('should return a spec with a title specified', () => {
+      const specM = buildSpecQueryModel({
+        title: 'Big Title',
+        mark: Mark.BAR,
+        encodings: [
+          {channel: Channel.X, field: 'O', type: Type.ORDINAL}
+        ]
+      });
+
+      assert.equal(specM.toSpec().title, 'Big Title');
+    });
   });
 });
 


### PR DESCRIPTION
Add support for background, title, padding-top level props.
Still remaining: AutoSize, but requires vega-lite dependency update (for future PR).

These appear in shorthand as a top-level prop, with string values appearing directly, e.g.:
`background: "gray"`

 and object values appearing in JSON.stringify format, e.g:
`title: {"text": "A Simple Bar Chart", "anchor": "start"}`