### PR TITLE
Add vscode setting to not add space between curly braces on auto-format

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
   },
   "files.trimTrailingWhitespace": true,
   "tslint.autoFixOnSave": true,
-  "tsimporter.spaceBetweenBraces": false,
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
   "typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
Adds rule to disable adding spaces between curly braces for imports within VSCode.

