### PR TITLE
fix: flagKeys issue

### DIFF
--- a/src/property.ts
+++ b/src/property.ts
@@ -3,10 +3,10 @@ import {BinParams} from 'vega-lite/build/src/bin';
 import {Legend, LEGEND_PROPERTIES} from 'vega-lite/build/src/legend';
 import {Scale, SCALE_PROPERTIES} from 'vega-lite/build/src/scale';
 import {EncodingSortField} from 'vega-lite/build/src/sort';
-import {Flag, flagKeys} from 'vega-lite/build/src/util';
+import {Flag} from 'vega-lite/build/src/util';
 import {AutoCountQuery, FieldQuery, ValueQuery} from './query/encoding';
 import {TransformQuery} from './query/transform';
-import {Diff} from './util';
+import {Diff, flagKeys} from './util';
 
 /**
  * There are two types of `Property`'s.

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import {isArray} from 'datalib/src/util';
+import {Flag} from 'vega-lite/build/src/util';
 
 export {cmp, keys, duplicate, extend, isObject, isBoolean, toMap} from 'datalib/src/util';
 
@@ -55,6 +56,10 @@ export function without<T>(array: Array<T>, excludedItems: Array<T>) {
   return array.filter(function(item) {
     return !contains(excludedItems, item);
   });
+}
+
+export function flagKeys<S extends string>(f: Flag<S>): S[] {
+  return Object.keys(f) as S[];
 }
 
 export type Diff<T extends string, U extends string> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];


### PR DESCRIPTION
flagKeys was recently removed from vega-lite, causing compassql to be incompatible with vega-lite 3.4.0 or above.