### PR TITLE
fix: move typescript-json-schema to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,11 +72,11 @@
     "ts-jest": "^23.10.5",
     "tslint": "~4.3.1",
     "typescript": "^3.4.5",
+    "typescript-json-schema": "^0.9.0",
     "vega-datasets": "latest"
   },
   "dependencies": {
     "datalib": "~1.7.0",
-    "typescript-json-schema": "^0.9.0",
     "vega-lite": "^3.3.0",
     "yargs": "^13.2.4"
   },


### PR DESCRIPTION
### Issue
Installing this package ends up installing typescript version 2.x due to `typescript-json-schema` being listed as a dependency instead of a devDependency.  

### Changes
Move `typescript-json-schema` into the devDependencies section of package.json.

### Testing
`yarn run build && yarn run test` succeeded.